### PR TITLE
Update docker image tag for 2.0 zfs updates

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -23,6 +23,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ixsystems/zfs:latest
+          tags: ixsystems/zfs:2.0-latest
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
Update docker image tag for 2.0 branch as using latest for both 2.1/2.0 will cause issues for consumers of the docker image as they can't reliably say when the tag is going to point to 2.0 or 2.1.