### PR TITLE
Make acltype=nfsv4 the default on Linux, too

### DIFF
--- a/man/man7/zfsprops.7
+++ b/man/man7/zfsprops.7
@@ -645,23 +645,18 @@ platform, the behavior is the same as if it were set to
 .Sy off .
 .Bl -tag -compact -offset 4n -width "posixacl"
 .It Sy off
-default on Linux, when a file system has the
+when a file system has the
 .Sy acltype
 property set to off then ACLs are disabled.
 .It Sy noacl
 an alias for
 .Sy off
 .It Sy nfsv4
-default on
-.Fx ,
-indicates that NFSv4-style ZFS ACLs should be used.
+default, indicates that NFSv4-style ZFS ACLs should be used.
 These ACLs can be managed with the
 .Xr getfacl 1
 and
 .Xr setfacl 1 .
-The
-.Sy nfsv4
-ZFS ACL type is not yet supported on Linux.
 .It Sy posix
 indicates POSIX ACLs should be used.
 POSIX ACLs are specific to Linux and are not functional on other platforms.

--- a/module/zcommon/zfs_prop.c
+++ b/module/zcommon/zfs_prop.c
@@ -435,13 +435,7 @@ zfs_prop_init(void)
 	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM,
 	    "discard | groupmask | passthrough | restricted", "ACLMODE",
 	    acl_mode_table);
-	zprop_register_index(ZFS_PROP_ACLTYPE, "acltype",
-#ifdef __linux__
-	    /* Linux doesn't natively support ZFS's NFSv4-style ACLs. */
-	    ZFS_ACLTYPE_OFF,
-#else
-	    ZFS_ACLTYPE_NFSV4,
-#endif
+	zprop_register_index(ZFS_PROP_ACLTYPE, "acltype", ZFS_ACLTYPE_NFSV4,
 	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM | ZFS_TYPE_SNAPSHOT,
 	    "off | nfsv4 | posix", "ACLTYPE", acltype_table);
 	zprop_register_index(ZFS_PROP_ACLINHERIT, "aclinherit",

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.get_index_props.zcp
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.get_index_props.zcp
@@ -27,11 +27,8 @@ props['checksum']           = {{'on',        'default'}, {nil,         nil}}
 props['dedup']              = {{'off',       'default'}, {nil,         nil}}
 props['compression']        = {{'off',       'default'}, {nil,         nil}}
 props['snapdir']            = {{'hidden',    'default'}, {nil,         nil}}
-if os == "Linux" then
-	props['acltype']    = {{'off',       'default'}, {'off', 'default'}}
-elseif os == "FreeBSD" then
-	props['aclmode']    = {{'discard',   'default'}, {'discard', 'default'}}
-end
+props['acltype']            = {{'nfsv4',     'default'}, {'nfsv4', 'default'}}
+props['aclmode']            = {{'discard',   'default'}, {'discard', 'default'}}
 props['aclinherit']         = {{'restricted','default'}, {nil,         nil}}
 props['copies']             = {{'1',         'default'}, {nil,         nil}}
 props['primarycache']       = {{'all',       'default'}, {'all', 'default'}}

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_get/zfs_get_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_get/zfs_get_001_pos.ksh
@@ -60,12 +60,12 @@ done
 typeset zfs_props=("type" used available creation volsize referenced \
     compressratio mounted origin recordsize quota reservation mountpoint \
     sharenfs checksum compression atime devices exec readonly setuid \
-    snapdir aclinherit canmount primarycache secondarycache version \
-    usedbychildren usedbydataset usedbyrefreservation usedbysnapshots)
+    snapdir aclinherit aclmode acltype canmount primarycache secondarycache \
+    version usedbychildren usedbydataset usedbyrefreservation usedbysnapshots)
 if is_freebsd; then
-	typeset zfs_props_os=(jailed aclmode)
+	typeset zfs_props_os=(jailed)
 else
-	typeset zfs_props_os=(zoned acltype)
+	typeset zfs_props_os=(zoned)
 fi
 typeset userquota_props=(userquota@root groupquota@root userused@root \
     groupused@root)

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_get/zfs_get_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_get/zfs_get_002_pos.ksh
@@ -50,12 +50,12 @@ typeset options=(" " p r H)
 typeset zfs_props=("type" used available creation volsize referenced \
     compressratio mounted origin recordsize quota reservation mountpoint \
     sharenfs checksum compression atime devices exec readonly setuid \
-    snapdir aclinherit canmount primarycache secondarycache version \
-    usedbychildren usedbydataset usedbyrefreservation usedbysnapshots)
+    snapdir aclinherit aclmode acltype canmount primarycache secondarycache \
+    version usedbychildren usedbydataset usedbyrefreservation usedbysnapshots)
 if is_freebsd; then
-	typeset zfs_props_os=(jailed aclmode)
+	typeset zfs_props_os=(jailed)
 else
-	typeset zfs_props_os=(zoned acltype)
+	typeset zfs_props_os=(zoned)
 fi
 typeset userquota_props=(userquota@root groupquota@root userused@root \
     groupused@root)

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_get/zfs_get_005_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_get/zfs_get_005_neg.ksh
@@ -48,12 +48,12 @@ typeset val_opts=(p r H)
 typeset v_props=(type used available creation volsize referenced compressratio \
     mounted origin recordsize quota reservation mountpoint sharenfs checksum \
     compression atime devices exec readonly setuid snapdir version \
-    aclinherit canmount primarycache secondarycache \
+    aclinherit aclmode acltype canmount primarycache secondarycache \
     usedbychildren usedbydataset usedbyrefreservation usedbysnapshots)
 if is_freebsd; then
-	typeset v_props_os=(jailed aclmode)
+	typeset v_props_os=(jailed)
 else
-	typeset v_props_os=(zoned acltype)
+	typeset v_props_os=(zoned)
 fi
 typeset  userquota_props=(userquota@root groupquota@root userused@root \
     groupused@root)

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_get/zfs_get_008_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_get/zfs_get_008_pos.ksh
@@ -53,13 +53,13 @@ set -A options " " "-r" "-H" "-p" "-rHp" "-o name" \
 set -A props type used available creation volsize referenced compressratio \
 	mounted origin recordsize quota reservation mountpoint sharenfs \
 	checksum compression atime devices exec readonly setuid snapdir \
-	aclinherit canmount primarycache secondarycache \
+	aclinherit aclmode acltype canmount primarycache secondarycache \
 	usedbychildren usedbydataset usedbyrefreservation usedbysnapshots \
 	userquota@root groupquota@root userused@root groupused@root
 if is_freebsd; then
-	set -A props ${props[*]} jailed aclmode
+	set -A props ${props[*]} jailed
 else
-	set -A props ${props[*]} zoned acltype
+	set -A props ${props[*]} zoned
 fi
 
 zfs upgrade -v > /dev/null 2>&1

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_get/zfs_get_009_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_get/zfs_get_009_pos.ksh
@@ -52,16 +52,16 @@ fi
 log_assert "'zfs get -d <n>' should get expected output."
 log_onexit depth_fs_cleanup
 
-set -A all_props type used available creation volsize referenced \
-	compressratio mounted origin recordsize quota reservation mountpoint \
-	sharenfs checksum compression atime devices exec readonly setuid \
-	snapdir aclinherit canmount primarycache secondarycache \
+set -A all_props type used available creation volsize referenced compressratio \
+	mounted origin recordsize quota reservation mountpoint sharenfs \
+	checksum compression atime devices exec readonly setuid snapdir \
+	aclinherit aclmode acltype canmount primarycache secondarycache \
 	usedbychildren usedbydataset usedbyrefreservation usedbysnapshots \
 	userquota@root groupquota@root userused@root groupused@root
 if is_freebsd; then
-	set -A all_props ${all_props[*]} jailed aclmode
+	set -A all_props ${all_props[*]} jailed
 else
-	set -A all_props ${all_props[*]} zoned acltype
+	set -A all_props ${all_props[*]} zoned
 fi
 
 zfs upgrade -v > /dev/null 2>&1

--- a/tests/zfs-tests/tests/functional/inheritance/inherit_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/inheritance/inherit_001_pos.ksh
@@ -376,6 +376,8 @@ function scan_state { #state-file
 #
 set -A prop "checksum" "" \
 	"compression" "" \
+	"aclmode" "" \
+	"acltype" "" \
 	"atime" "" \
 	"sharenfs" "" \
 	"recordsize" "recsize" \
@@ -388,12 +390,20 @@ set -A prop "checksum" "" \
 # above must have a corresponding entry in the two arrays below.
 #
 
-set -A def_val "on" "off" "on" \
+set -A def_val "on" \
+	"off" \
+	"discard" \
+	"nfsv4" \
+	"on" \
 	"off" "" \
 	"hidden" \
 	"off"
 
-set -A local_val "off" "on" "off" \
+set -A local_val "off" \
+	"on" \
+	"groupmask" \
+	"off" \
+	"off" \
 	"on" "" \
 	"visible" \
 	"off"
@@ -401,15 +411,6 @@ set -A local_val "off" "on" "off" \
 #
 # Add system specific values
 #
-if is_linux; then
-	prop+=("acltype" "")
-	def_val+=("off")
-	local_val+=("off")
-else
-	prop+=("aclmode" "")
-	def_val+=("discard")
-	local_val+=("groupmask")
-fi
 if is_illumos; then
 	prop+=("mountpoint" "")
 	def_val+=("")


### PR DESCRIPTION
Now that we support NFSv4 ACLs on Linux, this can now be made the
default across all platforms.

Update the documentation and tests accordingly.

Jira: NAS-111571