### PR TITLE
Write /sys/kernel/wait_for_device_probe before import.

### DIFF
--- a/contrib/initramfs/scripts/zfs
+++ b/contrib/initramfs/scripts/zfs
@@ -284,6 +284,7 @@ load_module_initrd()
 	fi
 
 	# Wait for all of the /dev/{hd,sd}[a-z] device nodes to appear.
+	echo "1" > /sys/kernel/wait_for_device_probe
 	if command -v wait_for_udev > /dev/null 2>&1 ; then
 		wait_for_udev 10
 	elif command -v wait_for_dev > /dev/null 2>&1 ; then


### PR DESCRIPTION
The new sysfs attribute makes kernel to wait for all device probe to
complete before return.  Without it wait_for_udev call does not give
any guaranties.

Ticket:	NAS-108200