### PR TITLE
NAS-111618: Fail invalid incremental recursive send gracefully

### DIFF
--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -1077,11 +1077,14 @@ dump_snapshot(zfs_handle_t *zhp, void *arg)
 			nvlist_t *nvfs = fsavl_find(sdd->fsavl,
 			    zhp->zfs_dmustats.dds_guid, &snapname);
 
-			VERIFY(0 == nvlist_lookup_nvlist(nvfs,
-			    "snapprops", &snapprops));
-			VERIFY(0 == nvlist_lookup_nvlist(snapprops,
-			    thissnap, &snapprops));
-			exclude = !nvlist_exists(snapprops, "is_clone_origin");
+			if (nvfs != NULL) {
+				verify(0 == nvlist_lookup_nvlist(nvfs,
+				    "snapprops", &snapprops));
+				verify(0 == nvlist_lookup_nvlist(snapprops,
+				    thissnap, &snapprops));
+				exclude = !nvlist_exists(snapprops,
+				    "is_clone_origin");
+			}
 		} else {
 			exclude = B_TRUE;
 		}

--- a/tests/zfs-tests/tests/functional/rsend/rsend_016_neg.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/rsend_016_neg.ksh
@@ -24,10 +24,22 @@
 #
 # Strategy:
 # 1. Perform a zfs incremental send from a bookmark that doesn't exist
+# 2. Perform a zfs incremental replication send with incremental source
+#    same as target (#11121)
 #
 
 verify_runnable "both"
 
-log_neg eval "zfs send -i \#bla $POOl/$FS@final > /dev/null"
+function cleanup
+{
+	rm -f $TEST_BASE_DIR/devnull
+}
+
+log_onexit cleanup
+
+log_mustnot eval "zfs send -i \#bla $POOl/$FS@final > $TEST_BASE_DIR/devnull"
+
+log_must eval "zfs send -R -i snapA $POOL/vol@snapA 2>&1 " \
+    "> $TEST_BASE_DIR/devnull | grep -q WARNING"
 
 log_pass "Ensure that error conditions cause appropriate failures."


### PR DESCRIPTION
zfs send -R -i snap1 pool/ds@snap1 is an invalid invocation of zfs send
because the incremental source and target snapshots are the same.  We
have an error message for this condition, but we don't make it there
because of a failed assert while iterating through the dataset's
snapshots.

Check for NULL to avoid the assert so we can make it to the error
message.

Test this form of invalid send invocation in rsend tests.  Fix the
rsend_016_neg test while here: log_neg itself doesn't fail the test,
and writing to /dev/null is not supported on all Linux kernels.