### PR TITLE
Fix access check when cred allows override of ACL

### DIFF
--- a/module/os/linux/zfs/policy.c
+++ b/module/os/linux/zfs/policy.c
@@ -119,10 +119,20 @@ secpolicy_vnode_access2(const cred_t *cr, struct inode *ip, uid_t owner,
 		return (0);
 	}
 
+	if (crgetfsuid(cr) == owner)
+		return (0);
+
+	if (zpl_inode_owner_or_capable(kcred->user_ns, ip))
+		return (0);
+
+#if defined(CONFIG_USER_NS)
+	if (!kuid_has_mapping(cr->user_ns, SUID_TO_KUID(owner)))
+		return (EPERM);
+#endif
 	/*
 	 * short-circuit if root
 	 */
-	if (capable(CAP_SYS_ADMIN)) {
+	if (priv_policy_user(cr, CAP_SYS_ADMIN, EPERM) == 0) {
 		return (0);
 	}
 
@@ -132,20 +142,22 @@ secpolicy_vnode_access2(const cred_t *cr, struct inode *ip, uid_t owner,
 	 */
 	if (S_ISDIR(ip->i_mode)) {
 		if (!(wantmode & S_IWUSR) &&
-		    capable(CAP_DAC_READ_SEARCH)) {
+		    (priv_policy_user(cr, CAP_DAC_READ_SEARCH, EPERM) == 0)) {
 			return (0);
 		}
-		if (capable(CAP_DAC_OVERRIDE)) {
+		if (priv_policy_user(cr, CAP_DAC_OVERRIDE, EPERM) == 0) {
 			return (0);
 		}
 		return (EACCES);
 	}
 
-	if ((wantmode == S_IRUSR) && capable(CAP_DAC_READ_SEARCH)) {
+	if ((wantmode == S_IRUSR) &&
+	    (priv_policy_user(cr, CAP_DAC_READ_SEARCH, EPERM) == 0)) {
 		return (0);
 	}
 
-	if (!(remainder & S_IXUSR) && capable(CAP_DAC_OVERRIDE)) {
+	if (!(remainder & S_IXUSR) &&
+	    (priv_policy_user(cr, CAP_DAC_OVERRIDE, EPERM) == 0)) {
 		return (0);
 	}
 

--- a/module/os/linux/zfs/zpl_xattr.c
+++ b/module/os/linux/zfs/zpl_xattr.c
@@ -106,7 +106,8 @@ static const struct {
 #endif
 };
 
-#define	GENERIC_MASK(mask) ((mask & ~(MAY_READ | MAY_WRITE | MAY_EXEC)) == 0)
+#define	POSIX_MASKS	(MAY_READ|MAY_WRITE|MAY_EXEC|MAY_OPEN)
+#define	GENERIC_MASK(mask) ((mask & ~POSIX_MASKS) == 0)
 
 enum xattr_permission {
 	XAPERM_DENY,


### PR DESCRIPTION
Properly evaluate edge cases where user credential may grant
capability to override DAC in various situations. Switch to
using ns-aware checks rather than capable().

Expand optimization allow bypass of zfs_zaccess() in case of
trivial ACL if MAY_OPEN is included in requested mask. This
will be evaluated in generic_permission() check, which is
RCU walk safe. This means that in most cases evaluating
permissions on boot volume with NFSv4 ACLs will follow the
fast path on checking inode permissions.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
