### PR TITLE
fix abort in make_dataset_handle_common

### DIFF
--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -455,6 +455,8 @@ make_dataset_handle_common(zfs_handle_t *zhp, zfs_cmd_t *zc)
 		zhp->zfs_head_type = ZFS_TYPE_FILESYSTEM;
 	else if (zhp->zfs_dmustats.dds_type == DMU_OST_OTHER)
 		return (-1);
+	else if (zhp->zfs_dmustats.dds_inconsistent != 0)
+		return (-1);
 	else
 		abort();
 


### PR DESCRIPTION
Running the zettarepl integration tests on TrueNAS will produce core
dumps for the middlewared process 100% of the time.

Crash is occurring in `make_dataset_handle_common` because `zfs_type` is
`DMU_OST_NONE`. Unfortunately, I haven't been successful in tracking
down whether or not this is a valid `zfs_type`. However, 100% of the
crashes that I've investigated from end-users as well as the ones that
were generated by the zettarepl integration tests show that
`dds_inconsistent` is 1. This means the filesystem is in the process of
being received or some case of destruction.

This changes `make_dataset_handle_common` to gracefully handle the
situation when `dds_inconsistent` != 0 and simply return -1 as to not
cause an `abort()`. Investigation has shown that other parts of the libzfs
API also have similar logic. With this change, the zettarepl integration
tests complete successfully and no more crashes occur.

Jira: NAS-113251