### PR TITLE
FreeBSD: Fix zvol_geom_open locking

### DIFF
--- a/module/os/freebsd/zfs/zvol_os.c
+++ b/module/os/freebsd/zfs/zvol_os.c
@@ -928,8 +928,8 @@ retry:
 		 */
 		if (!mutex_owned(&spa_namespace_lock)) {
 			if (!mutex_tryenter(&spa_namespace_lock)) {
-				rw_exit(&zvol_state_lock);
-				mutex_enter(&spa_namespace_lock);
+				mutex_exit(&zv->zv_state_lock);
+				rw_exit(&zv->zv_suspend_lock);
 				kern_yield(PRI_USER);
 				goto retry;
 			} else {


### PR DESCRIPTION
Some first open locking changes were applied correctly in zvol_cdev_open
but incorrectly in zvol_geom_open.