### PR TITLE
NAS-114773 / Make xattr_compat a tunable, zfs_xattr_compat

### DIFF
--- a/include/os/freebsd/zfs/sys/zfs_vfsops_os.h
+++ b/include/os/freebsd/zfs/sys/zfs_vfsops_os.h
@@ -240,9 +240,7 @@ struct zfsvfs {
 	RW_WRITE_HELD(&(zfsvfs)->z_teardown_inactive_lock)
 #endif
 
-#define	ZSB_XATTR		0x0001	/* Enable user xattrs */
-#define	ZSB_XATTR_COMPAT	0x0002	/* Enable cross-platform user xattrs */
-
+#define	ZSB_XATTR	0x0001		/* Enable user xattrs */
 /*
  * Normal filesystems (those not under .zfs/snapshot) have a total
  * file ID size limited to 12 bytes (including the length field) due to

--- a/include/os/linux/zfs/sys/zfs_vfsops_os.h
+++ b/include/os/linux/zfs/sys/zfs_vfsops_os.h
@@ -171,8 +171,7 @@ struct zfsvfs {
 #define	ZFS_TEARDOWN_HELD(zfsvfs)		\
 	RRM_LOCK_HELD(&(zfsvfs)->z_teardown_lock)
 
-#define	ZSB_XATTR		0x0001	/* Enable user xattrs */
-#define	ZSB_XATTR_COMPAT	0x0002	/* Enable cross-platform user xattrs */
+#define	ZSB_XATTR	0x0001		/* Enable user xattrs */
 
 /*
  * Allow a maximum number of links.  While ZFS does not internally limit

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -186,7 +186,6 @@ typedef enum {
 	ZFS_PROP_IVSET_GUID,		/* not exposed to the user */
 	ZFS_PROP_REDACTED,
 	ZFS_PROP_REDACT_SNAPS,
-	ZFS_PROP_XATTR_COMPAT,
 	ZFS_NUM_PROPS
 } zfs_prop_t;
 
@@ -457,11 +456,6 @@ typedef enum zfs_key_location {
 
 #define	DEFAULT_PBKDF2_ITERATIONS 350000
 #define	MIN_PBKDF2_ITERATIONS 100000
-
-typedef enum zfs_xattr_compat {
-	ZFS_XATTR_COMPAT_LINUX = 0,
-	ZFS_XATTR_COMPAT_ALL,
-} zfs_xattr_compat_t;
 
 /*
  * On-disk version number.

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -1999,8 +1999,7 @@
       <enumerator name='ZFS_PROP_IVSET_GUID' value='92'/>
       <enumerator name='ZFS_PROP_REDACTED' value='93'/>
       <enumerator name='ZFS_PROP_REDACT_SNAPS' value='94'/>
-      <enumerator name='ZFS_PROP_XATTR_COMPAT' value='95'/>
-      <enumerator name='ZFS_NUM_PROPS' value='96'/>
+      <enumerator name='ZFS_NUM_PROPS' value='95'/>
     </enum-decl>
     <typedef-decl name='zfs_prop_t' type-id='4b000d60' id='58603c44'/>
     <class-decl name='nvlist' size-in-bits='192' is-struct='yes' visibility='default' id='ac266fd9'>

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -2118,6 +2118,30 @@ When enabled, the maximum number of pending allocations per top-level vdev
 is limited by
 .Sy zfs_vdev_queue_depth_pct .
 .
+.It Sy zfs_xattr_compat Ns = Ns 0 Ns | Ns 1 Pq int
+Control the naming scheme used when setting new xattrs in the user namespace.
+If
+.Sy 0
+(the default on Linux), user namespace xattr names are prefixed with the
+namespace, to be backwards compatible with previous versions of ZFS on Linux.
+If
+.Sy 1
+(the default on
+.Fx ),
+user namespace xattr names are not prefixed, to be backwards compatible with
+previous versions of ZFS on illumos and
+.Fx .
+.Pp
+Either naming scheme can be read on this and future versions of ZFS, regardless
+of this tunable, but legacy ZFS on illumos or
+.Fx
+are unable to read user namespace xattrs written in the Linux format, and
+legacy versions of ZFS on Linux are unable to read user namespace xattrs
+written in the legacy ZFS format.
+.Pp
+An existing xattr with the alternate naming scheme is removed when overwriting
+the xattr so as to not accumulate duplicates.
+.
 .It Sy zio_requeue_io_start_cut_in_line Ns = Ns Sy 0 Ns | Ns 1 Pq int
 Prioritize requeued I/O.
 .

--- a/man/man7/zfsprops.7
+++ b/man/man7/zfsprops.7
@@ -1841,29 +1841,6 @@ are equivalent to the
 and
 .Sy noxattr
 mount options.
-.It Sy xattr_compat Ns = Ns Sy all Ns | Ns Sy linux
-Controls the preferred encoding of xattrs in the user namespace.
-When set to
-.Sy all
-(the default), xattrs written in the user namespace are stored in a
-format compatible across all supported platforms, and xattrs in the user
-namespace from all platforms are accessible.
-There is no notion of xattr namespaces on illumos, so all xattrs from
-illumos are presented in the user namespace on other platforms.
-The xattrs not in the user namespace are considered platform-specific and are
-not exposed on other platforms.
-Existing xattrs in the
-.Sy xattr_compat=linux
-format are accessible and are replaced with the cross-platform compatible
-format when written.
-When set to
-.Sy linux ,
-xattrs written in the user namespace are stored in a format that is compatible
-with upstream OpenZFS on Linux but not compatible with ZFS on other platforms.
-.Pp
-The default value in TrueNAS SCALE is
-.Sy xattr_compat=linux
-until this property is merged into upstream OpenZFS.
 .It Sy jailed Ns = Ns Sy off Ns | Ns Sy on
 Controls whether the dataset is managed from a jail.
 See

--- a/module/os/freebsd/zfs/zfs_vfsops.c
+++ b/module/os/freebsd/zfs/zfs_vfsops.c
@@ -494,21 +494,6 @@ xattr_changed_cb(void *arg, uint64_t newval)
 }
 
 static void
-xattr_compat_changed_cb(void *arg, uint64_t newval)
-{
-	zfsvfs_t *zfsvfs = arg;
-
-	switch (newval) {
-	case ZFS_XATTR_COMPAT_ALL:
-		zfsvfs->z_flags |= ZSB_XATTR_COMPAT;
-		break;
-	case ZFS_XATTR_COMPAT_LINUX:
-		zfsvfs->z_flags &= ~ZSB_XATTR_COMPAT;
-		break;
-	}
-}
-
-static void
 blksz_changed_cb(void *arg, uint64_t newval)
 {
 	zfsvfs_t *zfsvfs = arg;
@@ -751,9 +736,6 @@ zfs_register_callbacks(vfs_t *vfsp)
 	    zfs_prop_to_name(ZFS_PROP_ATIME), atime_changed_cb, zfsvfs);
 	error = error ? error : dsl_prop_register(ds,
 	    zfs_prop_to_name(ZFS_PROP_XATTR), xattr_changed_cb, zfsvfs);
-	error = error ? error : dsl_prop_register(ds,
-	    zfs_prop_to_name(ZFS_PROP_XATTR_COMPAT), xattr_compat_changed_cb,
-	    zfsvfs);
 	error = error ? error : dsl_prop_register(ds,
 	    zfs_prop_to_name(ZFS_PROP_RECORDSIZE), blksz_changed_cb, zfsvfs);
 	error = error ? error : dsl_prop_register(ds,
@@ -1270,10 +1252,6 @@ zfs_domount(vfs_t *vfsp, char *osname)
 		    "xattr", &pval, NULL)))
 			goto out;
 		xattr_changed_cb(zfsvfs, pval);
-		if ((error = dsl_prop_get_integer(osname,
-		    "xattr_compat", &pval, NULL)))
-			goto out;
-		xattr_compat_changed_cb(zfsvfs, pval);
 		if ((error = dsl_prop_get_integer(osname,
 		    "acltype", &pval, NULL)))
 			goto out;

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -353,21 +353,6 @@ xattr_changed_cb(void *arg, uint64_t newval)
 }
 
 static void
-xattr_compat_changed_cb(void *arg, uint64_t newval)
-{
-	zfsvfs_t *zfsvfs = arg;
-
-	switch (newval) {
-	case ZFS_XATTR_COMPAT_ALL:
-		zfsvfs->z_flags |= ZSB_XATTR_COMPAT;
-		break;
-	case ZFS_XATTR_COMPAT_LINUX:
-		zfsvfs->z_flags &= ~ZSB_XATTR_COMPAT;
-		break;
-	}
-}
-
-static void
 acltype_changed_cb(void *arg, uint64_t newval)
 {
 	zfsvfs_t *zfsvfs = arg;
@@ -525,9 +510,6 @@ zfs_register_callbacks(vfs_t *vfsp)
 	    zfs_prop_to_name(ZFS_PROP_RELATIME), relatime_changed_cb, zfsvfs);
 	error = error ? error : dsl_prop_register(ds,
 	    zfs_prop_to_name(ZFS_PROP_XATTR), xattr_changed_cb, zfsvfs);
-	error = error ? error : dsl_prop_register(ds,
-	    zfs_prop_to_name(ZFS_PROP_XATTR_COMPAT), xattr_compat_changed_cb,
-	    zfsvfs);
 	error = error ? error : dsl_prop_register(ds,
 	    zfs_prop_to_name(ZFS_PROP_RECORDSIZE), blksz_changed_cb, zfsvfs);
 	error = error ? error : dsl_prop_register(ds,
@@ -1551,10 +1533,6 @@ zfs_domount(struct super_block *sb, zfs_mnt_t *zm, int silent)
 		    "xattr", &pval, NULL)))
 			goto out;
 		xattr_changed_cb(zfsvfs, pval);
-		if ((error = dsl_prop_get_integer(osname,
-		    "xattr_compat", &pval, NULL)))
-			goto out;
-		xattr_compat_changed_cb(zfsvfs, pval);
 		if ((error = dsl_prop_get_integer(osname,
 		    "acltype", &pval, NULL)))
 			goto out;

--- a/module/zcommon/zfs_prop.c
+++ b/module/zcommon/zfs_prop.c
@@ -357,12 +357,6 @@ zfs_prop_init(void)
 		{ NULL }
 	};
 
-	static zprop_index_t xattr_compat_table[] = {
-		{ "linux",	ZFS_XATTR_COMPAT_LINUX },
-		{ "all",	ZFS_XATTR_COMPAT_ALL },
-		{ NULL }
-	};
-
 	static zprop_index_t dnsize_table[] = {
 		{ "legacy",	ZFS_DNSIZE_LEGACY },
 		{ "auto",	ZFS_DNSIZE_AUTO },
@@ -459,14 +453,6 @@ zfs_prop_init(void)
 	zprop_register_index(ZFS_PROP_XATTR, "xattr", ZFS_XATTR_DIR,
 	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM | ZFS_TYPE_SNAPSHOT,
 	    "on | off | dir | sa", "XATTR", xattr_table);
-	zprop_register_index(ZFS_PROP_XATTR_COMPAT, "xattr_compat",
-#ifdef __linux__
-	    ZFS_XATTR_COMPAT_LINUX,
-#else
-	    ZFS_XATTR_COMPAT_ALL,
-#endif
-	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM | ZFS_TYPE_SNAPSHOT,
-	    "all | linux", "XATTR_COMPAT", xattr_compat_table);
 	zprop_register_index(ZFS_PROP_DNODESIZE, "dnodesize",
 	    ZFS_DNSIZE_LEGACY, PROP_INHERIT, ZFS_TYPE_FILESYSTEM,
 	    "legacy | auto | 1k | 2k | 4k | 8k | 16k", "DNSIZE", dnsize_table);

--- a/tests/zfs-tests/include/properties.shlib
+++ b/tests/zfs-tests/include/properties.shlib
@@ -31,11 +31,10 @@ typeset -a redundant_metadata_prop_vals=('all' 'most')
 typeset -a secondarycache_prop_vals=('all' 'none' 'metadata')
 typeset -a snapdir_prop_vals=('hidden' 'visible')
 typeset -a sync_prop_vals=('standard' 'always' 'disabled')
-typeset -a xattr_compat_prop_vals=('all' 'linux')
 
 typeset -a fs_props=('compress' 'checksum' 'recsize'
     'canmount' 'copies' 'logbias' 'primarycache' 'redundant_metadata'
-    'secondarycache' 'snapdir' 'sync' 'xattr_compat')
+    'secondarycache' 'snapdir' 'sync')
 typeset -a vol_props=('compress' 'checksum' 'copies' 'logbias' 'primarycache'
     'secondarycache' 'redundant_metadata' 'sync')
 

--- a/tests/zfs-tests/include/tunables.cfg
+++ b/tests/zfs-tests/include/tunables.cfg
@@ -87,6 +87,7 @@ VDEV_VALIDATE_SKIP		vdev.validate_skip		vdev_validate_skip
 VOL_INHIBIT_DEV			UNSUPPORTED			zvol_inhibit_dev
 VOL_MODE			vol.mode			zvol_volmode
 VOL_RECURSIVE			vol.recursive			UNSUPPORTED
+XATTR_COMPAT			xattr_compat			zfs_xattr_compat
 ZEVENT_LEN_MAX			zevent.len_max			zfs_zevent_len_max
 ZEVENT_RETAIN_MAX		zevent.retain_max		zfs_zevent_retain_max
 ZIO_SLOW_IO_MS			zio.slow_io_ms			zio_slow_io_ms

--- a/tests/zfs-tests/tests/functional/xattr/Makefile.am
+++ b/tests/zfs-tests/tests/functional/xattr/Makefile.am
@@ -14,7 +14,8 @@ dist_pkgdata_SCRIPTS = \
 	xattr_010_neg.ksh \
 	xattr_011_pos.ksh \
 	xattr_012_pos.ksh \
-	xattr_013_pos.ksh
+	xattr_013_pos.ksh \
+	xattr_compat.ksh
 
 dist_pkgdata_DATA = \
 	xattr_common.kshlib \

--- a/tests/zfs-tests/tests/functional/xattr/xattr_compat.ksh
+++ b/tests/zfs-tests/tests/functional/xattr/xattr_compat.ksh
@@ -1,0 +1,92 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright 2022 iXsystems, Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# The zfs_xattr_compat tunable and fallback works as expected.
+#
+# STRATEGY:
+#	For both of xattr=sa and xattr=dir:
+#	1. Create a filesystem with zfs_xattr_compat=0
+#	2. Create a file on the filesystem and add some xattrs to it
+#	3. Change the zfs_xattr_compat tunable to 1
+#	4. Verify that the xattrs can still be accessed and modified
+#	5. Change zfs_xattr_compat back to 0 again
+#	6. Verify that the xattrs can still be accessed and modified
+#
+
+function cleanup {
+	rm -f $TESTFILE $TMPFILE
+	zfs set xattr=sa $TESTPOOL/$TESTFS
+	set_tunable32 XATTR_COMPAT $OLD_XATTR_COMPAT
+}
+
+log_assert "The zfs_xattr_compat tunable and fallback works as expected"
+log_onexit cleanup
+
+TESTFILE=$TESTDIR/testfile.$$
+TMPFILE=$TEST_BASE_DIR/tmpfile.$$
+OLD_XATTR_COMPAT=$(get_tunable XATTR_COMPAT)
+
+for x in sa dir; do
+	log_must zfs set xattr=$x $TESTPOOL/$TESTFS
+	log_must set_tunable32 XATTR_COMPAT 0
+	log_must touch $TESTFILE
+	log_must set_xattr testattr1 value1 $TESTFILE
+	log_must set_xattr testattr2 value2 $TESTFILE
+	log_must set_xattr testattr3 value3 $TESTFILE
+	log_must ls_xattr $TESTFILE
+
+	log_must set_tunable32 XATTR_COMPAT 1
+	log_must ls_xattr $TESTFILE
+	log_must eval "get_xattr testattr1 $TESTFILE > $TMPFILE"
+	log_must test $(<$TMPFILE) = value1
+	log_must set_xattr testattr2 newvalue2 $TESTFILE
+	log_must rm_xattr testattr3 $TESTFILE
+	log_must set_xattr testattr4 value4 $TESTFILE
+	log_must ls_xattr $TESTFILE
+
+	log_must set_tunable32 XATTR_COMPAT 0
+	log_must ls_xattr $TESTFILE
+	log_must eval "get_xattr testattr1 $TESTFILE > $TMPFILE"
+	log_must test $(<$TMPFILE) = value1
+	log_must eval "get_xattr testattr2 $TESTFILE > $TMPFILE"
+	log_must test $(<$TMPFILE) = newvalue2
+	log_mustnot get_xattr testattr3 $TESTFILE
+	log_must set_xattr testattr3 value3 $TESTFILE
+	log_must eval "get_xattr testattr4 $TESTFILE > $TMPFILE"
+	log_must test $(<$TMPFILE) = value4
+	log_must ls_xattr $TESTFILE
+
+	log_must rm $TESTFILE
+done
+
+log_pass "The zfs_xattr_compat tunable and fallback works as expected"


### PR DESCRIPTION
Upstream review has pushed away from having xattr_compat as a property.

Remove the property and make it a tunable instead.  Also add the test
changes from the upstream PR.

Jira: NAS-114773