### PR TITLE
Expose zpool guids through procfs

### DIFF
--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -918,6 +918,7 @@ typedef struct spa_stats {
 	spa_history_kstat_t	tx_assign_histogram;
 	spa_history_list_t	mmp_history;
 	spa_history_kstat_t	state;		/* pool state */
+	spa_history_kstat_t	guid;		/* pool guid */
 	spa_history_kstat_t	iostats;
 } spa_stats_t;
 

--- a/module/zfs/spa_stats.c
+++ b/module/zfs/spa_stats.c
@@ -819,10 +819,56 @@ spa_state_init(spa_t *spa)
 	kmem_strfree(name);
 }
 
+static int
+spa_guid_data(char *buf, size_t size, void *data)
+{
+	spa_t *spa = (spa_t *)data;
+	(void) snprintf(buf, size, "%llu\n", (u_longlong_t)spa_guid(spa));
+	return (0);
+}
+
+static void
+spa_guid_init(spa_t *spa)
+{
+	spa_history_kstat_t *shk = &spa->spa_stats.guid;
+	char *name;
+	kstat_t *ksp;
+
+	mutex_init(&shk->lock, NULL, MUTEX_DEFAULT, NULL);
+
+	name = kmem_asprintf("zfs/%s", spa_name(spa));
+
+	ksp = kstat_create(name, 0, "guid", "misc",
+	    KSTAT_TYPE_RAW, 0, KSTAT_FLAG_VIRTUAL);
+
+	shk->kstat = ksp;
+	if (ksp) {
+		ksp->ks_lock = &shk->lock;
+		ksp->ks_data = NULL;
+		ksp->ks_private = spa;
+		ksp->ks_flags |= KSTAT_FLAG_NO_HEADERS;
+		kstat_set_raw_ops(ksp, NULL, spa_guid_data, spa_state_addr);
+		kstat_install(ksp);
+	}
+
+	kmem_strfree(name);
+}
+
 static void
 spa_health_destroy(spa_t *spa)
 {
 	spa_history_kstat_t *shk = &spa->spa_stats.state;
+	kstat_t *ksp = shk->kstat;
+	if (ksp)
+		kstat_delete(ksp);
+
+	mutex_destroy(&shk->lock);
+}
+
+static void
+spa_guid_destroy(spa_t *spa)
+{
+	spa_history_kstat_t *shk = &spa->spa_stats.guid;
 	kstat_t *ksp = shk->kstat;
 	if (ksp)
 		kstat_delete(ksp);
@@ -950,6 +996,7 @@ spa_stats_init(spa_t *spa)
 	spa_tx_assign_init(spa);
 	spa_mmp_history_init(spa);
 	spa_state_init(spa);
+	spa_guid_init(spa);
 	spa_iostats_init(spa);
 }
 
@@ -962,6 +1009,7 @@ spa_stats_destroy(spa_t *spa)
 	spa_txg_history_destroy(spa);
 	spa_read_history_destroy(spa);
 	spa_mmp_history_destroy(spa);
+	spa_guid_destroy(spa);
 }
 
 /* BEGIN CSTYLED */


### PR DESCRIPTION
There are various places in middleware where we
look up zpool status and guid. Since the guid
is readily available through spa_guid() providing
via procfs is a significant enhancement because
it will reduce allow us to eliminate some frequent
libzfs / py-libzfs calls in favor of just reading
via procfs.

Signed-off-by: Andrew Walker <awalker@ixsystems.com>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
