### PR TITLE
FreeBSD: Silence clang unused-but-set-variable

### DIFF
--- a/module/Makefile.bsd
+++ b/module/Makefile.bsd
@@ -320,6 +320,7 @@ beforeinstall:
 
 
 CFLAGS.gcc+= -Wno-pointer-to-int-cast
+CFLAGS.clang+= ${NO_WUNUSED_BUT_SET_VARIABLE}
 
 CFLAGS.lapi.c= -Wno-cast-qual
 CFLAGS.lcompat.c= -Wno-cast-qual


### PR DESCRIPTION
Quick and dirty build fix for warnings being treated as errors.

Signed-off-by: Ryan Moeller <ryan@iXsystems.com>