### PR TITLE
NAS-116836 / Force BSD semantics for group ownership if NFSV4ACL

### DIFF
--- a/module/os/linux/zfs/zfs_vnops_os.c
+++ b/module/os/linux/zfs/zfs_vnops_os.c
@@ -600,6 +600,22 @@ zfs_create(znode_t *dzp, char *name, vattr_t *vap, int excl,
 	os = zfsvfs->z_os;
 	zilog = zfsvfs->z_log;
 
+	/*
+	 * For compatibility purposes with data migrated from FreeBSD
+	 * (which will have NFSv4 ACL type), BSD file creation semantics
+	 * are forced rather than System V. Hence on new file creation
+	 * if NFSV4ACL we inherit GID from parent rather than take current
+	 * process GID. This makes S_ISGID on directories a de-facto
+	 * no-op, but we still honor setting / removing it and normal
+	 * inheritance of the bit on new directories in case user changes
+	 * the underlying ACL type.
+	 */
+	if ((vap->va_mask & ATTR_MODE) &&
+	    S_ISDIR(ZTOI(dzp)->i_mode) &&
+	    (zfsvfs->z_acl_type == ZFS_ACLTYPE_NFSV4)) {
+		vap->va_gid = KGID_TO_SGID(ZTOI(dzp)->i_gid);
+	}
+
 	if (zfsvfs->z_utf8 && u8_validate(name, strlen(name),
 	    NULL, U8_VALIDATE_ENTIRE, &error) < 0) {
 		ZFS_EXIT(zfsvfs);
@@ -1222,6 +1238,22 @@ zfs_mkdir(znode_t *dzp, char *dirname, vattr_t *vap, znode_t **zpp,
 	ZFS_ENTER(zfsvfs);
 	ZFS_VERIFY_ZP(dzp);
 	zilog = zfsvfs->z_log;
+
+	/*
+	 * For compatibility purposes with data migrated from FreeBSD
+	 * (which will have NFSv4 ACL type), BSD file creation semantics
+	 * are forced rather than System V. Hence on new file creation
+	 * if NFSV4ACL we inherit GID from parent rather than take current
+	 * process GID. This makes S_ISGID on directories a de-facto
+	 * no-op, but we still honor setting / removing it and normal
+	 * inheritance of the bit on new directories in case user changes
+	 * the underlying ACL type.
+	 */
+	if ((vap->va_mask & ATTR_MODE) &&
+	    S_ISDIR(ZTOI(dzp)->i_mode) &&
+	    (zfsvfs->z_acl_type == ZFS_ACLTYPE_NFSV4)) {
+		vap->va_gid = KGID_TO_SGID(ZTOI(dzp)->i_gid);
+	}
 
 	if (dzp->z_pflags & ZFS_XATTR) {
 		ZFS_EXIT(zfsvfs);


### PR DESCRIPTION
When a new file is created on FreeBSD it is given the group
of the directory which contains it. On Linux it is given
to either the effective GID of the process (System V semantices)
or the GID of the parent directory (BSD semantics).

Since there is no hard-and-fast rule about creation semantics
for NFSv4 ACLs on Linux, we should opt for what is least likely
to break users permissions on change from FreeBSD to Linux.

Avoid setting actually setting the SGID bit on dirs unless
it was explicitly set.

Signed-off-by: Andrew Walker <awalker@ixsystems.com>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
