### PR TITLE
initramfs: Skip lvm scan before boot pool import

### DIFF
--- a/contrib/initramfs/scripts/local-top/zfs
+++ b/contrib/initramfs/scripts/local-top/zfs
@@ -48,6 +48,8 @@ activate_vg()
 }
 
 udev_settle
-activate_vg
+# TrueNAS SCALE doesn't boot from pools on top of LVM, and the scan can take a
+# significant amount of time on systems with a large number of disks.  Skip it.
+#activate_vg
 
 exit 0


### PR DESCRIPTION
TrueNAS SCALE doesn't boot from pools on top of LVM, and the scan can
take a significant amount of time on systems with a large number of
disks.

Skip the lvm commands in our local-top/zfs script.