### PR TITLE
Expose ZFS dataset case sensitivity setting via sb_opts

### DIFF
--- a/include/sys/mntent.h
+++ b/include/sys/mntent.h
@@ -108,5 +108,8 @@
 #define	MNTOPT_NOACL	"noacl"		/* likewise */
 #define	MNTOPT_POSIXACL	"posixacl"	/* likewise */
 #define	MNTOPT_MNTPOINT	"mntpoint"	/* mount point hint */
+#define	MNTOPT_CASESENSITIVE	"casesensitive"		/* case sensitivity */
+#define	MNTOPT_CASEINSENSITIVE	"caseinsensitive"	/* case insensitivity */
+#define	MNTOPT_CASEMIXED	"casemixed"		/* case mixed */
 
 #endif	/* _SYS_MNTENT_H */

--- a/lib/libzfs/os/linux/libzfs_mount_os.c
+++ b/lib/libzfs/os/linux/libzfs_mount_os.c
@@ -84,6 +84,13 @@ static const option_map_t option_map[] = {
 	{ MNTOPT_ACL,		MS_POSIXACL,	ZS_COMMENT	},
 	{ MNTOPT_NOACL,		MS_COMMENT,	ZS_COMMENT	},
 	{ MNTOPT_POSIXACL,	MS_POSIXACL,	ZS_COMMENT	},
+	/*
+	 * Case sensitive options are just listed here to silently
+	 * ignore the error if passed with zfs mount command.
+	 */
+	{ MNTOPT_CASESENSITIVE,		MS_COMMENT,	ZS_COMMENT	},
+	{ MNTOPT_CASEINSENSITIVE,	MS_COMMENT,	ZS_COMMENT	},
+	{ MNTOPT_CASEMIXED,		MS_COMMENT,	ZS_COMMENT	},
 #ifdef MS_NOATIME
 	{ MNTOPT_NOATIME,	MS_NOATIME,	ZS_COMMENT	},
 	{ MNTOPT_ATIME,		MS_COMMENT,	ZS_COMMENT	},

--- a/module/os/linux/zfs/zpl_super.c
+++ b/module/os/linux/zfs/zpl_super.c
@@ -236,6 +236,18 @@ __zpl_show_options(struct seq_file *seq, zfsvfs_t *zfsvfs)
 	}
 #endif /* CONFIG_FS_POSIX_ACL */
 
+	switch (zfsvfs->z_case) {
+	case ZFS_CASE_SENSITIVE:
+		seq_puts(seq, ",casesensitive");
+		break;
+	case ZFS_CASE_INSENSITIVE:
+		seq_puts(seq, ",caseinsensitive");
+		break;
+	default:
+		seq_puts(seq, ",casemixed");
+		break;
+	}
+
 	return (0);
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Expose ZFS dataset case sensitivity setting via sb_opts
Openzfs PR Link: https://github.com/openzfs/zfs/pull/13607
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
Through following commands:
``` cat /proc/mounts  | grep case``` 
``` mount  | grep case```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
