### PR TITLE
Add createtxg sort support for simple snapshot iterator

### DIFF
--- a/cmd/zfs/zfs_iter.c
+++ b/cmd/zfs/zfs_iter.c
@@ -219,6 +219,13 @@ zfs_sort_only_by_name(const zfs_sort_column_t *sc)
 	    sc->sc_prop == ZFS_PROP_NAME);
 }
 
+int
+zfs_sort_only_by_createtxg(const zfs_sort_column_t *sc)
+{
+	return (sc != NULL && sc->sc_next == NULL &&
+	    sc->sc_prop == ZFS_PROP_CREATETXG);
+}
+
 /* ARGSUSED */
 static int
 zfs_compare(const void *larg, const void *rarg, void *unused)
@@ -303,7 +310,7 @@ zfs_sort(const void *larg, const void *rarg, void *data)
 	for (psc = sc; psc != NULL; psc = psc->sc_next) {
 		char lbuf[ZFS_MAXPROPLEN], rbuf[ZFS_MAXPROPLEN];
 		char *lstr, *rstr;
-		uint64_t lnum, rnum;
+		uint64_t lnum = 0, rnum = 0;
 		boolean_t lvalid, rvalid;
 		int ret = 0;
 
@@ -354,11 +361,9 @@ zfs_sort(const void *larg, const void *rarg, void *data)
 			    zfs_get_type(r), B_FALSE);
 
 			if (lvalid)
-				(void) zfs_prop_get_numeric(l, psc->sc_prop,
-				    &lnum, NULL, NULL, 0);
+				lnum = zfs_prop_get_int(l, psc->sc_prop);
 			if (rvalid)
-				(void) zfs_prop_get_numeric(r, psc->sc_prop,
-				    &rnum, NULL, NULL, 0);
+				rnum = zfs_prop_get_int(r, psc->sc_prop);
 		}
 
 		if (!lvalid && !rvalid)

--- a/cmd/zfs/zfs_iter.h
+++ b/cmd/zfs/zfs_iter.h
@@ -53,6 +53,7 @@ int zfs_for_each(int, char **, int options, zfs_type_t,
 int zfs_add_sort_column(zfs_sort_column_t **, const char *, boolean_t);
 void zfs_free_sort_columns(zfs_sort_column_t *);
 int zfs_sort_only_by_name(const zfs_sort_column_t *);
+int zfs_sort_only_by_createtxg(const zfs_sort_column_t *);
 
 #ifdef	__cplusplus
 }

--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -3706,11 +3706,14 @@ zfs_do_list(int argc, char **argv)
 		fields = default_fields;
 
 	/*
-	 * If we are only going to list snapshot names and sort by name,
-	 * then we can use faster version.
+	 * If we are only going to list snapshot names and sort by name or
+	 * by createtxg, then we can use faster version.
 	 */
-	if (strcmp(fields, "name") == 0 && zfs_sort_only_by_name(sortcol))
+	if (strcmp(fields, "name") == 0 &&
+	    (zfs_sort_only_by_name(sortcol) ||
+	    zfs_sort_only_by_createtxg(sortcol))) {
 		flags |= ZFS_ITER_SIMPLE;
+	}
 
 	/*
 	 * If "-o space" and no types were specified, don't display snapshots.

--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -537,6 +537,7 @@ make_dataset_simple_handle_zc(zfs_handle_t *pzhp, zfs_cmd_t *zc)
 	zhp->zfs_head_type = pzhp->zfs_type;
 	zhp->zfs_type = ZFS_TYPE_SNAPSHOT;
 	zhp->zpool_hdl = zpool_handle(zhp);
+	zhp->zfs_dmustats = zc->zc_objset_stats;
 
 	return (zhp);
 }
@@ -2287,6 +2288,19 @@ get_numeric_property(zfs_handle_t *zhp, zfs_prop_t prop, zprop_source_t *src,
 	case ZFS_PROP_REDACTED:
 		*val = zhp->zfs_dmustats.dds_redacted;
 		break;
+
+	case ZFS_PROP_CREATETXG:
+		/*
+		 * We can directly read createtxg property from zfs
+		 * handle for Filesystem, Snapshot and ZVOL types.
+		 */
+		if ((zhp->zfs_type == ZFS_TYPE_FILESYSTEM) ||
+		    (zhp->zfs_type == ZFS_TYPE_SNAPSHOT) ||
+		    (zhp->zfs_type == ZFS_TYPE_VOLUME)) {
+			*val = zhp->zfs_dmustats.dds_creation_txg;
+			break;
+		}
+		fallthrough;
 
 	default:
 		switch (zfs_prop_get_type(prop)) {

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -2331,6 +2331,8 @@ zfs_ioc_snapshot_list_next(zfs_cmd_t *zc)
 		}
 
 		if (zc->zc_simple) {
+			zc->zc_objset_stats.dds_creation_txg =
+			    dsl_get_creationtxg(ds);
 			dsl_dataset_rele(ds, FTAG);
 			break;
 		}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Add support for createtxg sort for simple snapshot iterator
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
When iterating snapshots with name only, e.g., "-o name -s name", libzfs uses simple snapshot iterator and results are displayed in alphabetic order. This PR adds support for faster version of createtxg sort by avoiding nvlist parsing for properties. Flags "-o name -s createtxg" will enable createtxg sort while using simple snapshot iterator.
For 10,000 snapshots, following are the results:
``` 
time zfs list -t snapshot -o name -s createtxg  => 0m1.166s
time zfs list -t snapshot -o name -s name       => 0m1.245s
time zfs list -t snapshot -s createtxg          => 0m3.972s
```
Openzfs PR: https://github.com/openzfs/zfs/pull/13577

<!--- Describe your changes in detail -->

### How Has This Been Tested?
Created multiple snapshots for different datasets and verified that they are sorted w.r.t createtxg by using following command: 
```zfs list -t snapshot -o name -s createtxg```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
