### PR TITLE
Expose libzutil error info in libpc_handle_t

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -8590,8 +8590,12 @@ main(int argc, char **argv)
 		args.path = searchdirs;
 		args.can_be_active = B_TRUE;
 
-		error = zpool_find_config(NULL, target_pool, &cfg, &args,
-		    &libzpool_config_ops);
+		libpc_handle_t lpch = {
+			.lpc_lib_handle = NULL,
+			.lpc_ops = &libzpool_config_ops,
+			.lpc_printerr = B_TRUE
+		};
+		error = zpool_find_config(&lpch, target_pool, &cfg, &args);
 
 		if (error == 0) {
 

--- a/cmd/zhack/zhack.c
+++ b/cmd/zhack/zhack.c
@@ -135,8 +135,12 @@ zhack_import(char *target, boolean_t readonly)
 	g_importargs.can_be_active = readonly;
 	g_pool = strdup(target);
 
-	error = zpool_find_config(NULL, target, &config, &g_importargs,
-	    &libzpool_config_ops);
+	libpc_handle_t lpch = {
+		.lpc_lib_handle = NULL,
+		.lpc_ops = &libzpool_config_ops,
+		.lpc_printerr = B_TRUE
+	};
+	error = zpool_find_config(&lpch, target, &config, &g_importargs);
 	if (error)
 		fatal(NULL, FTAG, "cannot import '%s'", target);
 

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -3761,7 +3761,12 @@ zpool_do_import(int argc, char **argv)
 	idata.scan = do_scan;
 	idata.policy = policy;
 
-	pools = zpool_search_import(g_zfs, &idata, &libzfs_config_ops);
+	libpc_handle_t lpch = {
+		.lpc_lib_handle = g_zfs,
+		.lpc_ops = &libzfs_config_ops,
+		.lpc_printerr = B_TRUE
+	};
+	pools = zpool_search_import(&lpch, &idata);
 
 	if (pools != NULL && pool_exists &&
 	    (argc == 1 || strcmp(argv[0], argv[1]) == 0)) {
@@ -3819,7 +3824,7 @@ zpool_do_import(int argc, char **argv)
 		 */
 		idata.scan = B_TRUE;
 		nvlist_free(pools);
-		pools = zpool_search_import(g_zfs, &idata, &libzfs_config_ops);
+		pools = zpool_search_import(&lpch, &idata);
 
 		err = import_pools(pools, props, mntopts, flags,
 		    argc >= 1 ? argv[0] : NULL,

--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -7361,8 +7361,12 @@ ztest_import_impl(ztest_shared_t *zs)
 	args.path = searchdirs;
 	args.can_be_active = B_FALSE;
 
-	VERIFY0(zpool_find_config(NULL, ztest_opts.zo_pool, &cfg, &args,
-	    &libzpool_config_ops));
+	libpc_handle_t lpch = {
+		.lpc_lib_handle = NULL,
+		.lpc_ops = &libzpool_config_ops,
+		.lpc_printerr = B_TRUE
+	};
+	VERIFY0(zpool_find_config(&lpch, ztest_opts.zo_pool, &cfg, &args));
 	VERIFY0(spa_import(ztest_opts.zo_pool, cfg, NULL, flags));
 	fnvlist_free(cfg);
 }

--- a/include/libzutil.h
+++ b/include/libzutil.h
@@ -59,6 +59,15 @@ typedef const struct pool_config_ops {
 extern const pool_config_ops_t libzfs_config_ops;
 extern const pool_config_ops_t libzpool_config_ops;
 
+typedef enum lpc_error {
+	LPC_SUCCESS = 0,	/* no error -- success */
+	LPC_BADCACHE = 2000,	/* out of memory */
+	LPC_BADPATH,	/* must be an absolute path */
+	LPC_NOMEM,	/* out of memory */
+	LPC_EACCESS,	/* some devices require root privileges */
+	LPC_UNKNOWN
+} lpc_error_t;
+
 typedef struct importargs {
 	char **path;		/* a list of paths to search		*/
 	int paths;		/* number of paths to search		*/
@@ -70,10 +79,20 @@ typedef struct importargs {
 	nvlist_t *policy;	/* load policy (max txg, rewind, etc.)	*/
 } importargs_t;
 
-extern nvlist_t *zpool_search_import(void *, importargs_t *,
-    const pool_config_ops_t *);
-extern int zpool_find_config(void *, const char *, nvlist_t **, importargs_t *,
-    const pool_config_ops_t *);
+typedef struct libpc_handle {
+	int lpc_error;
+	boolean_t lpc_printerr;
+	boolean_t lpc_open_access_error;
+	boolean_t lpc_desc_active;
+	char lpc_desc[1024];
+	pool_config_ops_t *lpc_ops;
+	void *lpc_lib_handle;
+} libpc_handle_t;
+
+extern const char *libpc_error_description(libpc_handle_t *);
+extern nvlist_t *zpool_search_import(libpc_handle_t *, importargs_t *);
+extern int zpool_find_config(libpc_handle_t *, const char *, nvlist_t **,
+    importargs_t *);
 
 extern const char * const * zpool_default_search_paths(size_t *count);
 extern int zpool_read_label(int, nvlist_t **, int *);

--- a/lib/libzfs_core/libzfs_core.abi
+++ b/lib/libzfs_core/libzfs_core.abi
@@ -170,6 +170,7 @@
     <elf-symbol name='getzoneid' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='is_mpath_whole_disk' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='label_paths' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libpc_error_description' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='libspl_assertf' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='libzfs_core_fini' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='libzfs_core_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -2904,18 +2905,20 @@
       </data-member>
     </class-decl>
     <typedef-decl name='importargs_t' type-id='7ac83801' id='7a842a6b'/>
-    <typedef-decl name='pool_vdev_iter_f' type-id='6c16a6c8' id='dff793e0'/>
     <class-decl name='libpc_handle' size-in-bits='8448' is-struct='yes' visibility='default' id='7c8737f0'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='lpc_printerr' type-id='c19b74c3' visibility='default'/>
+        <var-decl name='lpc_error' type-id='95e97e5e' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='lpc_open_access_error' type-id='c19b74c3' visibility='default'/>
+        <var-decl name='lpc_printerr' type-id='c19b74c3' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='lpc_desc_active' type-id='c19b74c3' visibility='default'/>
+        <var-decl name='lpc_open_access_error' type-id='c19b74c3' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='lpc_desc_active' type-id='c19b74c3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
         <var-decl name='lpc_desc' type-id='b54ce520' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8320'>
@@ -2926,6 +2929,7 @@
       </data-member>
     </class-decl>
     <typedef-decl name='libpc_handle_t' type-id='7c8737f0' id='8a70a786'/>
+    <typedef-decl name='pool_vdev_iter_f' type-id='6c16a6c8' id='dff793e0'/>
     <pointer-type-def type-id='26a90f95' size-in-bits='64' id='9b23c9ad'/>
     <qualified-type-def type-id='8b092c69' const='yes' id='1a21babe'/>
     <pointer-type-def type-id='7a842a6b' size-in-bits='64' id='07ee4a58'/>
@@ -2936,6 +2940,10 @@
     <pointer-type-def type-id='b1e62775' size-in-bits='64' id='f095e320'/>
     <pointer-type-def type-id='b7c58eaa' size-in-bits='64' id='e7c00489'/>
     <pointer-type-def type-id='48b5725f' size-in-bits='64' id='eaa32e2f'/>
+    <function-decl name='libpc_error_description' mangled-name='libpc_error_description' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libpc_error_description'>
+      <parameter type-id='5507783b' name='hdl'/>
+      <return type-id='80f4b756'/>
+    </function-decl>
     <function-decl name='zutil_alloc' mangled-name='zutil_alloc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zutil_alloc'>
       <parameter type-id='5507783b' name='hdl'/>
       <parameter type-id='b59d7dce' name='size'/>
@@ -2965,17 +2973,15 @@
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zpool_search_import' mangled-name='zpool_search_import' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_search_import'>
-      <parameter type-id='eaa32e2f' name='hdl'/>
+      <parameter type-id='5507783b' name='hdl'/>
       <parameter type-id='07ee4a58' name='import'/>
-      <parameter type-id='f095e320' name='pco'/>
       <return type-id='5ce45b60'/>
     </function-decl>
     <function-decl name='zpool_find_config' mangled-name='zpool_find_config' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_config'>
-      <parameter type-id='eaa32e2f' name='hdl'/>
+      <parameter type-id='5507783b' name='hdl'/>
       <parameter type-id='80f4b756' name='target'/>
       <parameter type-id='857bb57e' name='configp'/>
       <parameter type-id='07ee4a58' name='args'/>
-      <parameter type-id='f095e320' name='pco'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='for_each_vdev_cb' mangled-name='for_each_vdev_cb' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='for_each_vdev_cb'>

--- a/lib/libzutil/zutil_import.c
+++ b/lib/libzutil/zutil_import.c
@@ -69,6 +69,30 @@
 
 #include "zutil_import.h"
 
+const char *
+libpc_error_description(libpc_handle_t *hdl)
+{
+	if (hdl->lpc_desc[0] != '\0')
+		return (hdl->lpc_desc);
+
+	switch (hdl->lpc_error) {
+	case LPC_BADCACHE:
+		return (dgettext(TEXT_DOMAIN, "invalid or missing cache file"));
+	case LPC_BADPATH:
+		return (dgettext(TEXT_DOMAIN, "must be an absolute path"));
+	case LPC_NOMEM:
+		return (dgettext(TEXT_DOMAIN, "out of memory"));
+	case LPC_EACCESS:
+		return (dgettext(TEXT_DOMAIN, "some devices require root "
+		    "privileges"));
+	case LPC_UNKNOWN:
+		return (dgettext(TEXT_DOMAIN, "unknown error"));
+	default:
+		assert(hdl->lpc_error == 0);
+		return (dgettext(TEXT_DOMAIN, "no error"));
+	}
+}
+
 /*PRINTFLIKE2*/
 static void
 zutil_error_aux(libpc_handle_t *hdl, const char *fmt, ...)
@@ -84,29 +108,28 @@ zutil_error_aux(libpc_handle_t *hdl, const char *fmt, ...)
 }
 
 static void
-zutil_verror(libpc_handle_t *hdl, const char *error, const char *fmt,
+zutil_verror(libpc_handle_t *hdl, lpc_error_t error, const char *fmt,
     va_list ap)
 {
 	char action[1024];
 
 	(void) vsnprintf(action, sizeof (action), fmt, ap);
+	hdl->lpc_error = error;
 
 	if (hdl->lpc_desc_active)
 		hdl->lpc_desc_active = B_FALSE;
 	else
 		hdl->lpc_desc[0] = '\0';
 
-	if (hdl->lpc_printerr) {
-		if (hdl->lpc_desc[0] != '\0')
-			error = hdl->lpc_desc;
-
-		(void) fprintf(stderr, "%s: %s\n", action, error);
-	}
+	if (hdl->lpc_printerr)
+		(void) fprintf(stderr, "%s: %s\n", action,
+		    libpc_error_description(hdl));
 }
 
 /*PRINTFLIKE3*/
 static int
-zutil_error_fmt(libpc_handle_t *hdl, const char *error, const char *fmt, ...)
+zutil_error_fmt(libpc_handle_t *hdl, lpc_error_t error,
+    const char *fmt, ...)
 {
 	va_list ap;
 
@@ -120,7 +143,7 @@ zutil_error_fmt(libpc_handle_t *hdl, const char *error, const char *fmt, ...)
 }
 
 static int
-zutil_error(libpc_handle_t *hdl, const char *error, const char *msg)
+zutil_error(libpc_handle_t *hdl, lpc_error_t error, const char *msg)
 {
 	return (zutil_error_fmt(hdl, error, "%s", msg));
 }
@@ -128,7 +151,7 @@ zutil_error(libpc_handle_t *hdl, const char *error, const char *msg)
 static int
 zutil_no_memory(libpc_handle_t *hdl)
 {
-	zutil_error(hdl, EZFS_NOMEM, "internal error");
+	zutil_error(hdl, LPC_NOMEM, "internal error");
 	exit(1);
 }
 
@@ -1229,8 +1252,8 @@ zpool_find_import_scan_dir(libpc_handle_t *hdl, pthread_mutex_t *lock,
 			return (0);
 
 		zutil_error_aux(hdl, strerror(error));
-		(void) zutil_error_fmt(hdl, EZFS_BADPATH, dgettext(
-		    TEXT_DOMAIN, "cannot resolve path '%s'"), dir);
+		(void) zutil_error_fmt(hdl, LPC_BADPATH, dgettext(TEXT_DOMAIN,
+		    "cannot resolve path '%s'"), dir);
 		return (error);
 	}
 
@@ -1238,8 +1261,8 @@ zpool_find_import_scan_dir(libpc_handle_t *hdl, pthread_mutex_t *lock,
 	if (dirp == NULL) {
 		error = errno;
 		zutil_error_aux(hdl, strerror(error));
-		(void) zutil_error_fmt(hdl, EZFS_BADPATH,
-		    dgettext(TEXT_DOMAIN, "cannot open '%s'"), path);
+		(void) zutil_error_fmt(hdl, LPC_BADPATH, dgettext(TEXT_DOMAIN,
+		    "cannot open '%s'"), path);
 		return (error);
 	}
 
@@ -1286,8 +1309,8 @@ zpool_find_import_scan_path(libpc_handle_t *hdl, pthread_mutex_t *lock,
 		}
 
 		zutil_error_aux(hdl, strerror(error));
-		(void) zutil_error_fmt(hdl, EZFS_BADPATH, dgettext(
-		    TEXT_DOMAIN, "cannot resolve path '%s'"), dir);
+		(void) zutil_error_fmt(hdl, LPC_BADPATH, dgettext(TEXT_DOMAIN,
+		    "cannot resolve path '%s'"), dir);
 		goto out;
 	}
 
@@ -1325,7 +1348,7 @@ zpool_find_import_scan(libpc_handle_t *hdl, pthread_mutex_t *lock,
 				continue;
 
 			zutil_error_aux(hdl, strerror(error));
-			(void) zutil_error_fmt(hdl, EZFS_BADPATH, dgettext(
+			(void) zutil_error_fmt(hdl, LPC_BADPATH, dgettext(
 			    TEXT_DOMAIN, "cannot resolve path '%s'"), dir[i]);
 			goto error;
 		}
@@ -1540,16 +1563,16 @@ zpool_find_import_cached(libpc_handle_t *hdl, importargs_t *iarg)
 
 	if ((fd = open(iarg->cachefile, O_RDONLY | O_CLOEXEC)) < 0) {
 		zutil_error_aux(hdl, "%s", strerror(errno));
-		(void) zutil_error(hdl, EZFS_BADCACHE,
-		    dgettext(TEXT_DOMAIN, "failed to open cache file"));
+		(void) zutil_error(hdl, LPC_BADCACHE, dgettext(TEXT_DOMAIN,
+		    "failed to open cache file"));
 		return (NULL);
 	}
 
 	if (fstat64(fd, &statbuf) != 0) {
 		zutil_error_aux(hdl, "%s", strerror(errno));
 		(void) close(fd);
-		(void) zutil_error(hdl, EZFS_BADCACHE,
-		    dgettext(TEXT_DOMAIN, "failed to get size of cache file"));
+		(void) zutil_error(hdl, LPC_BADCACHE, dgettext(TEXT_DOMAIN,
+		    "failed to get size of cache file"));
 		return (NULL);
 	}
 
@@ -1561,8 +1584,7 @@ zpool_find_import_cached(libpc_handle_t *hdl, importargs_t *iarg)
 	if (read(fd, buf, statbuf.st_size) != statbuf.st_size) {
 		(void) close(fd);
 		free(buf);
-		(void) zutil_error(hdl, EZFS_BADCACHE,
-		    dgettext(TEXT_DOMAIN,
+		(void) zutil_error(hdl, LPC_BADCACHE, dgettext(TEXT_DOMAIN,
 		    "failed to read cache file contents"));
 		return (NULL);
 	}
@@ -1571,8 +1593,7 @@ zpool_find_import_cached(libpc_handle_t *hdl, importargs_t *iarg)
 
 	if (nvlist_unpack(buf, statbuf.st_size, &raw, 0) != 0) {
 		free(buf);
-		(void) zutil_error(hdl, EZFS_BADCACHE,
-		    dgettext(TEXT_DOMAIN,
+		(void) zutil_error(hdl, LPC_BADCACHE, dgettext(TEXT_DOMAIN,
 		    "invalid or corrupt cache file contents"));
 		return (NULL);
 	}
@@ -1741,26 +1762,20 @@ zpool_find_import(libpc_handle_t *hdl, importargs_t *iarg)
 
 
 nvlist_t *
-zpool_search_import(void *hdl, importargs_t *import,
-    const pool_config_ops_t *pco)
+zpool_search_import(libpc_handle_t *hdl, importargs_t *import)
 {
-	libpc_handle_t handle = { 0 };
 	nvlist_t *pools = NULL;
-
-	handle.lpc_lib_handle = hdl;
-	handle.lpc_ops = pco;
-	handle.lpc_printerr = B_TRUE;
 
 	verify(import->poolname == NULL || import->guid == 0);
 
 	if (import->cachefile != NULL)
-		pools = zpool_find_import_cached(&handle, import);
+		pools = zpool_find_import_cached(hdl, import);
 	else
-		pools = zpool_find_import(&handle, import);
+		pools = zpool_find_import(hdl, import);
 
 	if ((pools == NULL || nvlist_empty(pools)) &&
-	    handle.lpc_open_access_error && geteuid() != 0) {
-		(void) zutil_error(&handle, EZFS_EACESS, dgettext(TEXT_DOMAIN,
+	    hdl->lpc_open_access_error && geteuid() != 0) {
+		(void) zutil_error(hdl, LPC_EACCESS, dgettext(TEXT_DOMAIN,
 		    "no pools found"));
 	}
 
@@ -1784,8 +1799,8 @@ pool_match(nvlist_t *cfg, char *tgt)
 }
 
 int
-zpool_find_config(void *hdl, const char *target, nvlist_t **configp,
-    importargs_t *args, const pool_config_ops_t *pco)
+zpool_find_config(libpc_handle_t *hdl, const char *target, nvlist_t **configp,
+    importargs_t *args)
 {
 	nvlist_t *pools;
 	nvlist_t *match = NULL;
@@ -1799,7 +1814,7 @@ zpool_find_config(void *hdl, const char *target, nvlist_t **configp,
 	if ((sepp = strpbrk(targetdup, "/@")) != NULL)
 		*sepp = '\0';
 
-	pools = zpool_search_import(hdl, args, pco);
+	pools = zpool_search_import(hdl, args);
 
 	if (pools != NULL) {
 		nvpair_t *elem = NULL;

--- a/lib/libzutil/zutil_import.h
+++ b/lib/libzutil/zutil_import.h
@@ -28,25 +28,10 @@
 #ifndef _LIBZUTIL_ZUTIL_IMPORT_H_
 #define	_LIBZUTIL_ZUTIL_IMPORT_H_
 
-#define	EZFS_BADCACHE	"invalid or missing cache file"
-#define	EZFS_BADPATH	"must be an absolute path"
-#define	EZFS_NOMEM	"out of memory"
-#define	EZFS_EACESS	"some devices require root privileges"
-
 #define	IMPORT_ORDER_PREFERRED_1	1
 #define	IMPORT_ORDER_PREFERRED_2	2
 #define	IMPORT_ORDER_SCAN_OFFSET	10
 #define	IMPORT_ORDER_DEFAULT		100
-
-typedef struct libpc_handle {
-	boolean_t lpc_printerr;
-	boolean_t lpc_open_access_error;
-	boolean_t lpc_desc_active;
-	char lpc_desc[1024];
-	const pool_config_ops_t *lpc_ops;
-	void *lpc_lib_handle;
-} libpc_handle_t;
-
 
 int label_paths(libpc_handle_t *hdl, nvlist_t *label, char **path,
     char **devid);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
In `libzutil`, for `zpool_search_import` and `zpool_find_config`, we use `libpc_handle_t`
internally, which does not maintain error code and it is not exposed in the interface.
Due to this, the error information is not propagated to the caller. Instead, an error
message is printed on stderr.

### Description
This commit adds `lpc_error` field in `libpc_handle_t` and exposes the handle in the
interface, which can be used by the users of `libzutil` to get the appropriate error
information and handle it accordingly.

Users of the API can also control if they want to print the error message on stderr.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
