### PR TITLE
Skip permission checks for POSIX ACL type

### DIFF
--- a/module/os/linux/zfs/zfs_acl.c
+++ b/module/os/linux/zfs/zfs_acl.c
@@ -2608,8 +2608,13 @@ zfs_zaccess_common(znode_t *zp, uint32_t v4_mode, uint32_t *working_mode,
 		return (SET_ERROR(EPERM));
 	}
 
-	if (zp->z_pflags & ZFS_ACL_TRIVIAL)
+	/*
+	 * Workaround for POSIX ACL type to avoid deadlock
+	 */
+	if ((zp->z_pflags & ZFS_ACL_TRIVIAL) &&
+	    zfsvfs->z_acl_type != ZFS_ACLTYPE_POSIX) {
 		return (zfs_zaccess_trivial(zp, working_mode, cr));
+	}
 
 	return (zfs_zaccess_aces_check(zp, working_mode, B_FALSE, cr));
 }


### PR DESCRIPTION
zfs_zaccess_trivial() calls the generic_permission() to read xattr attributes. This may cause a deadlock if the xattr and dent locks are already held. This commit adds a workaround to skip permission checks for the POSIX ACL type.

**Upstream Fix (In progress)**: https://github.com/openzfs/zfs/pull/14220

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
```
USER_NON_ROOT=$USER
truncate -s 1G /tmp/f1
zpool create tank /tmp/f1 -f
zfs create -o xattr=dir -o acltype=posix -o mountpoint=/data tank/data
echo "TEMP" > /data/file1
chown $USER_NON_ROOT:$USER_NON_ROOT /data/file1
setfacl -m u:$USER_NON_ROOT:rwx /data/file1
```
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
