### PR TITLE
NAS-120113 / Do not toggle ZFS_ARCHIVE on mtime updates

### DIFF
--- a/module/os/linux/zfs/zfs_znode.c
+++ b/module/os/linux/zfs/zfs_znode.c
@@ -1426,12 +1426,39 @@ zfs_tstamp_update_setup(znode_t *zp, uint_t flag, uint64_t mtime[2],
 
 	zp->z_seq++;
 
+	/*
+	 * Implementation note regarding ZFS_ARCHIVE:
+	 * ZFS_ARCHIVE represents the Microsoft file attribute
+	 * FILE_ATTRIBUTE_ARCHIVE, which is defined in MS-FSCC section 2.6 as
+	 * follows:
+	 *
+	 * "A file or directory that requires to be archived. Applications use
+	 * this attribute to mark files for backup or removal."
+	 *
+	 * Implementation guidelines for when the filesystem should set
+	 * FILE_ATTRIBUTE_ARCHIVE are defined in the Microsoft document MS-FSA.
+	 * In summary, the bit must be set on changes to: file data, extended
+	 * attributes, alternate data streams, hard links to file, adding and
+	 * deleting reparse points, altering encyption status of file, changes
+	 * to file's 8.3 name, and file rename.
+	 *
+	 * Of particular relevance to implementation on ZFS is that changes to
+	 * FileBasicInformation (Section 2.1.5.14.2) must not cause
+	 * FILE_ATTRIBUTE_ARCHIVE to be set.
+	 *
+	 * FileBasicInformation is documented in MS-FSCC 2.4.7 as encompassing
+	 * CreationTime, LastAccessTime, LastWriteTime ChangeTime, and
+	 * FileAttributes (ZFS_ARCHIVE, ZFS_READONLY, etc).
+	 *
+	 * Accordingly, altering timestamps via futimens(), utimensat(), and
+	 * related syscalls should not set ZFS_ARCHIVE. ZFS_ARCHIVE is set
+	 * coincidentally with ctime changes.
+	 */
 	if (flag & ATTR_MTIME) {
 		ZFS_TIME_ENCODE(&now, mtime);
 		ZFS_TIME_DECODE(&(ZTOI(zp)->i_mtime), mtime);
 		if (ZTOZSB(zp)->z_use_fuids) {
-			zp->z_pflags |= (ZFS_ARCHIVE |
-			    ZFS_AV_MODIFIED);
+			zp->z_pflags |= ZFS_AV_MODIFIED;
 		}
 	}
 


### PR DESCRIPTION
ZFS_ARCHIVE is an internal representation of the
Microsoft file attribute FILE_ATTRIBUTE_ARCHIVE.

This attribute should not be set on simple mtime
updates. Explanation in context with Microsoft
documentation is below.

MS-FSCC 2.6 File Attributes contains the following explanation of this bit:

A file or directory that requires to be archived.
Applications use this attribute to mark files for
backup or removal.

MS-FSA lists some situations in which archive is
set as follows:

1) 2.1.4.17 File has been modified
This appears to specifically refer to file data
it is accompanied by changes to mtime, ctime, and
atime.

2) 2.1.5.1.1 Creation of a new file

3) 2.1.5.1.2 Open of an Existing File
If a new alternate data stream is created for the
existing file. In typical SMB configurations,
alternate data streams are written as xattrs in
ZFS.

4) 2.1.5.9.3 FSCTL_DELETE_REPARSE_POINT
Successful removal of reparse point associated
with the file.

5) 2.1.5.9.32 FSCL_SET_ENCRYPTION
On change of encrpytion status

6) 2.1.5.9.37 FSCTL_SET_REPARSE_POINT
On setting reparse point if file type is DataFile.

7) 2.1.5.14.5 FullFileEaInformation
EA is altered. Not that EAs are not identical
to alternate data streams. EAs are an NTFS-only
feature that were implemented for OS/2 compatibility.

8) 2.1.5.14.6 FileLinkInformation
Creation / removal of hard link.

9) 2.1.5.14.11 FileRenameInformation
File has been renamed

10) 2.1.5.14.13 FileShortNameInformation
8.3 name has been changed. This does not apply to ZFS.

Changes to FileBasicInformation (2.1.5.14.2) do not cause FILE_ATTRIBUTE_ARCHIVE to be set.

FileBasicInformation is documented in MS-FSCC 2.4.7 as impacting CreationTime, LastAccessTime, LastWriteTime, ChangeTime, and FileAttributes.

Based on this reading altering timestamps via futimens(), utimensat(), and similar syscalls should not set
ZFS_ARCHIVE.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
