### PR TITLE
linux 6.3 compat changes for truenas/zfs-2.2-release

### DIFF
--- a/include/os/linux/zfs/sys/zpl.h
+++ b/include/os/linux/zfs/sys/zpl.h
@@ -105,6 +105,8 @@ zpl_chmod_acl(struct inode *ip)
 #if defined(HAVE_IOPS_PERMISSION_USERNS)
 extern int zpl_permission(struct user_namespace *userns, struct inode *ip,
     int mask);
+#elif defined(HAVE_IOPS_PERMISSION_IDMAP)
+extern int zpl_permission(struct mnt_idmap *idmap, struct inode *ip, int mask);
 #else
 extern int zpl_permission(struct inode *ip, int mask);
 #endif

--- a/module/os/linux/zfs/policy.c
+++ b/module/os/linux/zfs/policy.c
@@ -123,7 +123,7 @@ secpolicy_vnode_access2(const cred_t *cr, struct inode *ip, uid_t owner,
 	if ((uid == owner) || (uid == 0))
 		return (0);
 
-	if (zpl_inode_owner_or_capable(kcred->user_ns, ip))
+	if (zpl_inode_owner_or_capable(zfs_init_idmap, ip))
 		return (0);
 
 #if defined(CONFIG_USER_NS)

--- a/module/os/linux/zfs/zpl_xattr.c
+++ b/module/os/linux/zfs/zpl_xattr.c
@@ -1498,6 +1498,8 @@ static xattr_handler_t zpl_xattr_acl_default_handler = {
 int
 #if defined(HAVE_IOPS_PERMISSION_USERNS)
 zpl_permission(struct user_namespace *userns, struct inode *ip, int mask)
+#elif defined(HAVE_IOPS_PERMISSION_IDMAP)
+zpl_permission(struct mnt_idmap *idmap, struct inode *ip, int mask)
 #else
 zpl_permission(struct inode *ip, int mask)
 #endif
@@ -1513,8 +1515,9 @@ zpl_permission(struct inode *ip, int mask)
 	 */
 	if ((ITOZSB(ip)->z_acl_type != ZFS_ACLTYPE_NFSV4) ||
 	    ((ITOZ(ip)->z_pflags & ZFS_ACL_TRIVIAL && GENERIC_MASK(mask)))) {
-#if defined(HAVE_IOPS_PERMISSION_USERNS)
-		return (generic_permission(userns, ip, mask));
+#if (defined(HAVE_IOPS_PERMISSION_USERNS) || \
+	defined(HAVE_IOPS_PERMISSION_IDMAP))
+		return (generic_permission(zfs_init_idmap, ip, mask));
 #else
 		return (generic_permission(ip, mask));
 #endif
@@ -1531,8 +1534,9 @@ zpl_permission(struct inode *ip, int mask)
 	 * NFSv4 ACE. Pass back to default kernel permissions check.
 	 */
 	if (to_check == 0) {
-#if defined(HAVE_IOPS_PERMISSION_USERNS)
-		return (generic_permission(userns, ip, mask));
+#if (defined(HAVE_IOPS_PERMISSION_USERNS) || \
+	defined(HAVE_IOPS_PERMISSION_IDMAP))
+		return (generic_permission(zfs_init_idmap, ip, mask));
 #else
 		return (generic_permission(ip, mask));
 #endif


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->
The CI workflow was no longer compiling successfully after its container recently moved to Linux 6.3. This patch adds compatibility support for Linux kernel 6.3 for the truenas zfs-2.2 branch.

### How Has This Been Tested?
By testing build on 5.15, 6.1, and 6.3 kernel versions.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
