### PR TITLE
NAS-122578 / None / Make zfsd executable in order to run it from the rc.d script

### DIFF
--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -22,13 +22,12 @@ SHELLCHECKSCRIPTS   += $(sysconf_zfs_DATA)
 $(call SHELLCHECK_OPTS,$(sysconf_zfs_DATA)): SHELLCHECK_SHELL = sh
 
 if BUILD_FREEBSD
-sysconf_zfsddir = $(sysconfdir)/rc.d
+rcdir = $(sysconfdir)/rc.d
+rc_SCRIPTS = %D%/rc.d/zfsd
 
-sysconf_zfsd_DATA = %D%/rc.d/zfsd
-
-SUBSTFILES          += $(sysconf_zfsd_DATA)
-SHELLCHECKSCRIPTS   += $(sysconf_zfsd_DATA)
-$(call SHELLCHECK_OPTS,$(sysconf_zfsd_DATA)): SHELLCHECK_SHELL = sh
+SUBSTFILES        += $(rc_SCRIPTS)
+SHELLCHECKSCRIPTS += $(rc_SCRIPTS)
+$(call SHELLCHECK_OPTS,$(rc_SCRIPTS)): SHELLCHECK_SHELL = sh
 endif
 
 if BUILD_LINUX

--- a/etc/rc.d/Makefile.am
+++ b/etc/rc.d/Makefile.am
@@ -1,7 +1,0 @@
-include $(top_srcdir)/config/Substfiles.am
-
-EXTRA_DIST += zfsd.in
-
-init_SCRIPTS = zfsd
-
-SUBSTFILES += $(init_SCRIPTS)


### PR DESCRIPTION
After updating to zfs-2.2, zfsd does not start at boot on Core due to executable permissions missing. 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Through core-build and by verifying that zfsd runs at startup

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
