### PR TITLE
NAS-123369 / 23.10 / Packaging: Move zinject from openzfs-zfs-test to openzfs-zfsutils package

### DIFF
--- a/contrib/debian/openzfs-zfs-test.install
+++ b/contrib/debian/openzfs-zfs-test.install
@@ -1,10 +1,8 @@
-sbin/zinject
 sbin/ztest
 usr/bin/raidz_test
 usr/share/man/man1/raidz_test.1
 usr/share/man/man1/test-runner.1
 usr/share/man/man1/ztest.1
-usr/share/man/man8/zinject.8
 usr/share/zfs/common.sh
 usr/share/zfs/runfiles/
 usr/share/zfs/test-runner

--- a/contrib/debian/openzfs-zfsutils.install
+++ b/contrib/debian/openzfs-zfsutils.install
@@ -27,6 +27,7 @@ sbin/zfs
 sbin/zfs_ids_to_path
 sbin/zgenhostid
 sbin/zhack
+sbin/zinject
 sbin/zpool
 sbin/zstream
 sbin/zstreamdump
@@ -92,6 +93,7 @@ usr/share/man/man8/zfs_ids_to_path.8
 usr/share/man/man7/zfsconcepts.7
 usr/share/man/man7/zfsprops.7
 usr/share/man/man8/zgenhostid.8
+usr/share/man/man8/zinject.8
 usr/share/man/man8/zpool-add.8
 usr/share/man/man8/zpool-attach.8
 usr/share/man/man8/zpool-checkpoint.8


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For native Debian packages, `zinject` and it's man page is packaged in ZFS test package. `zinject` is not not directly related to ZTS and should be packaged with other utilities, like it is already present in `zfs_<ver>.rpm/deb` packages. This can be particularly useful where we want to use `zinject` but don't want to install ZTS on the system.


### Description
This commit moves `zinject` binary and man page from `openzfs-zfs-test` to `openzfs-zfsutils` package.

### How Has This Been Tested?
Tested by building and installing native Debian packages.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
