### PR TITLE
NAS-123279 / 24.04 / Ignore errors due to sharesmb/sharenfs on pool import

### DIFF
--- a/contrib/debian/rules.in
+++ b/contrib/debian/rules.in
@@ -168,7 +168,6 @@ override_dh_installinit:
 	dh_installinit -r --no-restart-after-upgrade --name zfs-import
 	dh_installinit -r --no-restart-after-upgrade --name zfs-mount
 	dh_installinit -r --no-restart-after-upgrade --name zfs-load-key
-	dh_installinit -R --name zfs-share
 	dh_installinit -R --name zfs-zed
 
 override_dh_installsystemd:

--- a/etc/systemd/system/50-zfs.preset
+++ b/etc/systemd/system/50-zfs.preset
@@ -3,7 +3,7 @@ enable zfs-import-cache.service
 disable zfs-import-scan.service
 enable zfs-import.target
 enable zfs-mount.service
-enable zfs-share.service
+disable zfs-share.service
 enable zfs-zed.service
 enable zfs-volume-wait.service
 enable zfs.target

--- a/etc/systemd/system/zfs-share.service.in
+++ b/etc/systemd/system/zfs-share.service.in
@@ -17,4 +17,4 @@ EnvironmentFile=-@initconfdir@/zfs
 ExecStart=@sbindir@/zfs share -a
 
 [Install]
-WantedBy=zfs.target
+WantedBy=multi-user.target

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -156,6 +156,7 @@ typedef enum zfs_error {
 	EZFS_NOT_USER_NAMESPACE,	/* a file is not a user namespace */
 	EZFS_CKSUM,		/* insufficient replicas */
 	EZFS_RESUME_EXISTS,	/* Resume on existing dataset without force */
+	EZFS_SHAREFAILED,	/* filesystem share failed */
 	EZFS_UNKNOWN
 } zfs_error_t;
 

--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -1300,7 +1300,7 @@ zpool_enable_datasets(zpool_handle_t *zhp, const char *mntopts, int flags)
 	zfs_foreach_mountpoint(zhp->zpool_hdl, cb.cb_handles, cb.cb_used,
 	    zfs_mount_one, &ms, B_TRUE);
 	if (ms.ms_mntstatus != 0)
-		ret = ms.ms_mntstatus;
+		ret = EZFS_MOUNTFAILED;
 
 	/*
 	 * Share all filesystems that need to be shared. This needs to be
@@ -1311,7 +1311,7 @@ zpool_enable_datasets(zpool_handle_t *zhp, const char *mntopts, int flags)
 	zfs_foreach_mountpoint(zhp->zpool_hdl, cb.cb_handles, cb.cb_used,
 	    zfs_share_one, &ms, B_FALSE);
 	if (ms.ms_mntstatus != 0)
-		ret = ms.ms_mntstatus;
+		ret = EZFS_SHAREFAILED;
 	else
 		zfs_commit_shares(NULL);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
For users who have `sharesmb/sharenfs` property set to `on`, when they try to import the 
pool on TrueNAS, they run into error and pool import fails.

### Description
For `zpool import` and `zpool split`, `zpool_enable_datasets` is called to mount and share
all datasets in a pool. If there is an error while mounting or sharing any dataset in the pool,
the status of import or split is reported as failure. However, the changes do show up in
zpool list.

This PR updates the error reporting in zpool import and zpool split path. More
descriptive messages are shown to user in case there is an error during mount or
share. Errors in mount or share do not effect the overall status of `zpool import` and
`zpool split`.

`zfs-share.service` executes `zfs share -a` on every boot to share any filesystems with
sharesmb/sharenfs properties enabled. This PR also disables this service.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
