### PR TITLE
NAS-125208 / None / Remove inode_owner_or_capable override for secpolicy

### DIFF
--- a/module/os/linux/zfs/policy.c
+++ b/module/os/linux/zfs/policy.c
@@ -120,10 +120,7 @@ secpolicy_vnode_access2(const cred_t *cr, struct inode *ip, uid_t owner,
 		return (0);
 	}
 
-	if ((uid == owner) || (uid == 0))
-		return (0);
-
-	if (zpl_inode_owner_or_capable(zfs_init_idmap, ip))
+	if (uid == 0)
 		return (0);
 
 #if defined(CONFIG_USER_NS)


### PR DESCRIPTION
This commit fixes a bug whereby owner@ ACL that limits WRITE_DATA access for the owner of a file was not being properly enforced. The owner of a file should be prevented from write access in this case, but being owner of file should still allow the file owner to chmod, chown, and setacl.