### PR TITLE
[release/23.10.1] Block Cloning Fixes

### DIFF
--- a/include/os/freebsd/spl/sys/debug.h
+++ b/include/os/freebsd/spl/sys/debug.h
@@ -39,12 +39,14 @@
  * ASSERT3U()	- Assert unsigned X OP Y is true, if not panic.
  * ASSERT3P()	- Assert pointer X OP Y is true, if not panic.
  * ASSERT0()	- Assert value is zero, if not panic.
+ * ASSERT0P()	- Assert pointer is null, if not panic.
  * VERIFY()	- Verify X is true, if not panic.
  * VERIFY3B()	- Verify boolean X OP Y is true, if not panic.
  * VERIFY3S()	- Verify signed X OP Y is true, if not panic.
  * VERIFY3U()	- Verify unsigned X OP Y is true, if not panic.
  * VERIFY3P()	- Verify pointer X OP Y is true, if not panic.
  * VERIFY0()	- Verify value is zero, if not panic.
+ * VERIFY0P()	- Verify pointer is null, if not panic.
  */
 
 #ifndef _SPL_DEBUG_H
@@ -136,6 +138,15 @@ spl_assert(const char *buf, const char *file, const char *func, int line)
 		    (long long) (_verify3_right));			\
 	} while (0)
 
+#define	VERIFY0P(RIGHT)	do {						\
+		const uintptr_t _verify0_right = (uintptr_t)(RIGHT);	\
+		if (unlikely(!(0 == _verify0_right)))			\
+		    spl_panic(__FILE__, __FUNCTION__, __LINE__,		\
+		    "VERIFY0P(" #RIGHT ") "				\
+		    "failed (NULL == %p)\n",				\
+		    (void *)_verify0_right);				\
+	} while (0)
+
 /*
  * Debugging disabled (--disable-debug)
  */
@@ -151,6 +162,7 @@ spl_assert(const char *buf, const char *file, const char *func, int line)
 #define	ASSERT3P(x, y, z)						\
 	((void) sizeof ((uintptr_t)(x)), (void) sizeof ((uintptr_t)(z)))
 #define	ASSERT0(x)		((void) sizeof ((uintptr_t)(x)))
+#define	ASSERT0P(x)		((void) sizeof ((uintptr_t)(x)))
 #define	IMPLY(A, B)							\
 	((void) sizeof ((uintptr_t)(A)), (void) sizeof ((uintptr_t)(B)))
 #define	EQUIV(A, B)		\
@@ -166,6 +178,7 @@ spl_assert(const char *buf, const char *file, const char *func, int line)
 #define	ASSERT3U	VERIFY3U
 #define	ASSERT3P	VERIFY3P
 #define	ASSERT0		VERIFY0
+#define	ASSERT0P	VERIFY0P
 #define	ASSERT		VERIFY
 #define	IMPLY(A, B) \
 	((void)(likely((!(A)) || (B)) ||				\

--- a/include/os/linux/spl/sys/debug.h
+++ b/include/os/linux/spl/sys/debug.h
@@ -34,12 +34,14 @@
  * ASSERT3U()	- Assert unsigned X OP Y is true, if not panic.
  * ASSERT3P()	- Assert pointer X OP Y is true, if not panic.
  * ASSERT0()	- Assert value is zero, if not panic.
+ * ASSERT0P()	- Assert pointer is null, if not panic.
  * VERIFY()	- Verify X is true, if not panic.
  * VERIFY3B()	- Verify boolean X OP Y is true, if not panic.
  * VERIFY3S()	- Verify signed X OP Y is true, if not panic.
  * VERIFY3U()	- Verify unsigned X OP Y is true, if not panic.
  * VERIFY3P()	- Verify pointer X OP Y is true, if not panic.
  * VERIFY0()	- Verify value is zero, if not panic.
+ * VERIFY0P()	- Verify pointer is null, if not panic.
  */
 
 #ifndef _SPL_DEBUG_H
@@ -140,6 +142,15 @@ spl_assert(const char *buf, const char *file, const char *func, int line)
 		    (long long) (_verify3_right));			\
 	} while (0)
 
+#define	VERIFY0P(RIGHT)	do {						\
+		const uintptr_t _verify0_right = (uintptr_t)(RIGHT);	\
+		if (unlikely(!(0 == _verify0_right)))			\
+		    spl_panic(__FILE__, __FUNCTION__, __LINE__,		\
+		    "VERIFY0P(" #RIGHT ") "				\
+		    "failed (NULL == %px)\n",				\
+		    (void *)_verify0_right);				\
+	} while (0)
+
 #define	VERIFY_IMPLY(A, B) \
 	((void)(likely((!(A)) || (B)) ||				\
 	    spl_assert("(" #A ") implies (" #B ")",			\
@@ -165,6 +176,7 @@ spl_assert(const char *buf, const char *file, const char *func, int line)
 #define	ASSERT3P(x, y, z)						\
 	((void) sizeof ((uintptr_t)(x)), (void) sizeof ((uintptr_t)(z)))
 #define	ASSERT0(x)		((void) sizeof ((uintptr_t)(x)))
+#define	ASSERT0P(x)		((void) sizeof ((uintptr_t)(x)))
 #define	IMPLY(A, B)							\
 	((void) sizeof ((uintptr_t)(A)), (void) sizeof ((uintptr_t)(B)))
 #define	EQUIV(A, B)		\
@@ -180,6 +192,7 @@ spl_assert(const char *buf, const char *file, const char *func, int line)
 #define	ASSERT3U	VERIFY3U
 #define	ASSERT3P	VERIFY3P
 #define	ASSERT0		VERIFY0
+#define	ASSERT0P	VERIFY0P
 #define	ASSERT		VERIFY
 #define	IMPLY		VERIFY_IMPLY
 #define	EQUIV		VERIFY_EQUIV

--- a/lib/libspl/include/assert.h
+++ b/lib/libspl/include/assert.h
@@ -120,6 +120,15 @@ do {									\
 		    (u_longlong_t)__left);				\
 } while (0)
 
+#define	VERIFY0P(LEFT)							\
+do {									\
+	const uintptr_t __left = (uintptr_t)(LEFT);			\
+	if (!(__left == 0))						\
+		libspl_assertf(__FILE__, __FUNCTION__, __LINE__,	\
+		    "%s == 0 (%p == 0)", #LEFT,				\
+		    (void *)__left);					\
+} while (0)
+
 #ifdef assert
 #undef assert
 #endif
@@ -134,6 +143,7 @@ do {									\
 #define	ASSERT3P(x, y, z)						\
 	((void) sizeof ((uintptr_t)(x)), (void) sizeof ((uintptr_t)(z)))
 #define	ASSERT0(x)		((void) sizeof ((uintptr_t)(x)))
+#define	ASSERT0P(x)		((void) sizeof ((uintptr_t)(x)))
 #define	ASSERT(x)		((void) sizeof ((uintptr_t)(x)))
 #define	assert(x)		((void) sizeof ((uintptr_t)(x)))
 #define	IMPLY(A, B)							\
@@ -146,6 +156,7 @@ do {									\
 #define	ASSERT3U	VERIFY3U
 #define	ASSERT3P	VERIFY3P
 #define	ASSERT0		VERIFY0
+#define	ASSERT0P	VERIFY0P
 #define	ASSERT		VERIFY
 #define	assert		VERIFY
 #define	IMPLY(A, B) \

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -1904,7 +1904,6 @@ dbuf_unoverride(dbuf_dirty_record_t *dr)
 	dmu_buf_impl_t *db = dr->dr_dbuf;
 	blkptr_t *bp = &dr->dt.dl.dr_overridden_by;
 	uint64_t txg = dr->dr_txg;
-	boolean_t release;
 
 	ASSERT(MUTEX_HELD(&db->db_mtx));
 	/*
@@ -1925,7 +1924,10 @@ dbuf_unoverride(dbuf_dirty_record_t *dr)
 	if (!BP_IS_HOLE(bp) && !dr->dt.dl.dr_nopwrite)
 		zio_free(db->db_objset->os_spa, txg, bp);
 
-	release = !dr->dt.dl.dr_brtwrite;
+	if (dr->dt.dl.dr_brtwrite) {
+		ASSERT0P(dr->dt.dl.dr_data);
+		dr->dt.dl.dr_data = db->db_buf;
+	}
 	dr->dt.dl.dr_override_state = DR_NOT_OVERRIDDEN;
 	dr->dt.dl.dr_nopwrite = B_FALSE;
 	dr->dt.dl.dr_brtwrite = B_FALSE;
@@ -1939,7 +1941,7 @@ dbuf_unoverride(dbuf_dirty_record_t *dr)
 	 * the buf thawed to save the effort of freezing &
 	 * immediately re-thawing it.
 	 */
-	if (release)
+	if (dr->dt.dl.dr_data)
 		arc_release(dr->dt.dl.dr_data, db);
 }
 

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2930,7 +2930,8 @@ dbuf_assign_arcbuf(dmu_buf_impl_t *db, arc_buf_t *buf, dmu_tx_t *tx)
 	while (db->db_state == DB_READ || db->db_state == DB_FILL)
 		cv_wait(&db->db_changed, &db->db_mtx);
 
-	ASSERT(db->db_state == DB_CACHED || db->db_state == DB_UNCACHED);
+	ASSERT(db->db_state == DB_CACHED || db->db_state == DB_UNCACHED ||
+	    db->db_state == DB_NOFILL);
 
 	if (db->db_state == DB_CACHED &&
 	    zfs_refcount_count(&db->db_holds) - 1 > db->db_dirtycnt) {
@@ -2967,6 +2968,15 @@ dbuf_assign_arcbuf(dmu_buf_impl_t *db, arc_buf_t *buf, dmu_tx_t *tx)
 			arc_buf_destroy(db->db_buf, db);
 		}
 		db->db_buf = NULL;
+	} else if (db->db_state == DB_NOFILL) {
+		/*
+		 * We will be completely replacing the cloned block.  In case
+		 * it was cloned in this transaction group, let's undirty the
+		 * pending clone and mark the block as uncached. This will be
+		 * as if the clone was never done.
+		 */
+		VERIFY(!dbuf_undirty(db, tx));
+		db->db_state = DB_UNCACHED;
 	}
 	ASSERT(db->db_buf == NULL);
 	dbuf_set_data(db, buf);


### PR DESCRIPTION
This pull request includes recent block cloning fixes by @amotin. Details are mentioned in individual commits.

### How Has This Been Tested?
- CI testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
