### PR TITLE
NAS-128470 / None / Fix return value for setting zvol threading

### DIFF
--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -372,7 +372,7 @@ zvol_set_volthreading(const char *name, boolean_t value)
 {
 	zvol_state_t *zv = zvol_find_by_name(name, RW_NONE);
 	if (zv == NULL)
-		return (ENOENT);
+		return (-1);
 	zv->zv_threading = value;
 	mutex_exit(&zv->zv_state_lock);
 	return (0);


### PR DESCRIPTION
This commit fixes the ability to change the zvol threading property on a locked vzol.

zvol_find_by_name() returns NULL for encrypted and locked zvols. Rather than failing with ENOENT (which causes the originating libzfs operation - for example zfs_prop_set_list() to fail with "dataset does not exist") we should simply return -1. This allows the zvol property to be set as expected when the zvol is locked.