### PR TITLE
NAS-128470 / 24.04.1 / Fix return value for setting zvol threading (#230)

### DIFF
--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -377,7 +377,7 @@ zvol_set_volthreading(const char *name, boolean_t value)
 {
 	zvol_state_t *zv = zvol_find_by_name(name, RW_NONE);
 	if (zv == NULL)
-		return (ENOENT);
+		return (-1);
 	zv->zv_threading = value;
 	mutex_exit(&zv->zv_state_lock);
 	return (0);


### PR DESCRIPTION
We must return -1 instead of ENOENT if the special zvol threading property set function can't locate the dataset (this would typically happen with an encypted and unmounted zvol) so that the operation gets inserted properly into the nvlist for operations to set. This is because we want the property to be set once the zvol is decrypted again