### PR TITLE
NAS-130043 / None / Update zed.rc to disable emailing

### DIFF
--- a/cmd/zed/zed.d/zed.rc
+++ b/cmd/zed/zed.d/zed.rc
@@ -14,7 +14,7 @@
 # Email will only be sent if ZED_EMAIL_ADDR is defined.
 # Enabled by default; comment to disable.
 #
-ZED_EMAIL_ADDR="root"
+#ZED_EMAIL_ADDR="root"
 
 ##
 # Name or path of executable responsible for sending notifications via email;


### PR DESCRIPTION
ZED has an emailing service separate from middleware. This leads to getting emails from ZED that don't relate to anything on our WebUI which can be confusing (and alarming). Commenting out `ZED_EMAIL_ADDR` will disable the email service.