### PR TITLE
NAS-130522 / 24.10 / Fix namespace handling in zpl_permission (#244)

### DIFF
--- a/module/os/linux/zfs/zfs_acl.c
+++ b/module/os/linux/zfs/zfs_acl.c
@@ -2442,8 +2442,11 @@ zfs_zaccess_aces_check(znode_t *zp, uint32_t *working_mode,
 			break;
 		case OWNING_GROUP:
 			who = gowner;
-			zfs_fallthrough;
+			checkit = zfs_groupmember(zfsvfs, who, cr);
+			break;
 		case ACE_IDENTIFIER_GROUP:
+			who = zfs_gid_to_vfsgid(mnt_ns, zfs_i_user_ns(ZTOI(zp)),
+			    who);
 			checkit = zfs_groupmember(zfsvfs, who, cr);
 			break;
 		case ACE_EVERYONE:
@@ -2454,6 +2457,8 @@ zfs_zaccess_aces_check(znode_t *zp, uint32_t *working_mode,
 		default:
 			if (entry_type == 0) {
 				uid_t newid;
+				who = zfs_uid_to_vfsuid(mnt_ns,
+				    zfs_i_user_ns(ZTOI(zp)), who);
 
 				newid = zfs_fuid_map_id(zfsvfs, who, cr,
 				    ZFS_ACE_USER);


### PR DESCRIPTION
This commit fixes user / idmap namespaces in zpl_permission. ZFS updates to address kernel changes were subtly broken and passing the wrong namespace to generic_permission().

Since zpl_permission was initially written, zfs_zaccess() has become idmap-aware. This commit switches from using zfs_access to zfs_zaccess() and improves zfs_zaccess_aces_check() so that uids / gids in ACL entries are converted via idmap configuration prior to checking access.
