### PR TITLE
NAS-127825 / 25.04 / Fix inconsistent mount options for ZFS root

### DIFF
--- a/contrib/initramfs/scripts/zfs
+++ b/contrib/initramfs/scripts/zfs
@@ -345,7 +345,7 @@ mount_fs()
 
 	# Need the _original_ datasets mountpoint!
 	mountpoint=$(get_fs_value "$fs" mountpoint)
-	ZFS_CMD="mount -o zfsutil -t zfs"
+	ZFS_CMD="mount.zfs -o zfsutil"
 	if [ "$mountpoint" = "legacy" ] || [ "$mountpoint" = "none" ]; then
 		# Can't use the mountpoint property. Might be one of our
 		# clones. Check the 'org.zol:mountpoint' property set in
@@ -360,9 +360,8 @@ mount_fs()
 				# isn't the root fs.
 				return 0
 			fi
-			# Don't use mount.zfs -o zfsutils for legacy mountpoint
 			if [ "$mountpoint" = "legacy" ]; then
-				ZFS_CMD="mount -t zfs"
+				ZFS_CMD="mount.zfs"
 			fi
 			# Last hail-mary: Hope 'rootmnt' is set!
 			mountpoint=""

--- a/include/os/linux/zfs/sys/zfs_vfsops_os.h
+++ b/include/os/linux/zfs/sys/zfs_vfsops_os.h
@@ -69,6 +69,7 @@ typedef struct vfs {
 	boolean_t	vfs_do_relatime;
 	boolean_t	vfs_nbmand;
 	boolean_t	vfs_do_nbmand;
+	kmutex_t	vfs_mntpt_lock;
 } vfs_t;
 
 typedef struct zfs_mnt {


### PR DESCRIPTION
### Motivation and Context
Backport of https://github.com/openzfs/zfs/pull/16646 for TrueNAS ZFS.

### Description
While mounting ZFS root during boot on Linux distributions from initrd, mount from busybox is effectively used which executes `mount` system call directly. This skips the ZFS helper `mount.zfs`, which checks and enables the mount options as specified in dataset properties. As a result, datasets mounted during boot from initrd do not have correct mount options as specified in ZFS dataset properties.

There has been an attempt to use `mount.zfs` in zfs initrd script, responsible for mounting the ZFS root filesystem ([PR#13305](https://github.com/openzfs/zfs/pull/13305)). This was later reverted ([PR#14908](https://github.com/openzfs/zfs/pull/14908)) after discovering that using mount.zfs breaks mounting of snapshots on root (`/`) and child datasets of root have the same issue ([Issue#9461](https://github.com/openzfs/zfs/issues/9461)).

This happens because switching from busybox mount to mount.zfs correctly parses the mount options but also adds `mntpoint=/root` to the mount options, which is then prepended to the snapshot mountpoint in `.zfs/snapshot`. `/root` is the directory on Debian with `initramfs-tools` where root filesystem is mounted before `pivot_root`. When Linux runtime is reached, trying to access the snapshots on root results in automounting the snapshot on `/root/.zfs/*`, which fails.

This commit attempts to fix the automounting of snapshots on root, while using `mount.zfs` in initrd script. Since the mountpoint of dataset is stored in `vfs_mntpoint` field, we can check if current mountpoint of dataset and `vfs_mntpoint` are same or not. If they are not same, reset the `vfs_mntpoint` field with current mountpoint. This fixes the mountpoints of root dataset and children in respective `vfs_mntpoint` fields when we try to access the snapshots of root dataset or its children. With correct mountpoint for root dataset and children stored in `vfs_mntpoint`, all snapshots of root dataset are mounted correctly and become accessible.

This fix will come into play only if current process, that is trying to access the snapshots is not in chroot context. The Linux kernel API that is used to convert struct path into char format (`d_path`), returns the complete path for given `struct path`. It works in chroot environment as well and returns the correct path from original filesystem root.

However, `d_path` fails to return the complete path if any directory from original root filesystem is mounted using `--bind` flag or `--rbind` flag in chroot environment. In this case, if we try to access the snapshot from outside the chroot environment, `d_path` returns the path correctly, i.e. it returns the correct path to the directory that is mounted with `--bind` flag. However inside the chroot environment, it only returns the path inside chroot.

For now, there is not a better way in my understanding that gives the complete path in char format and handles the case where directories from root filesystem are mounted with `--bind` or `--rbind` on another path which user will later chroot into. So this fix gets enabled if current process trying to access the snapshot is not in chroot context.

With the snapshots issue fixed for root filesystem, using `mount.zfs` in ZFS initrd script, mounts the datasets with correct mount options.

### How Has This Been Tested?

- ZFS root and it's child datasets are mounted with correct mount options during boot
- Snapshots of root and child datasets are accessible on `/` while using `mount.zfs` to mount ZFS root during boot.
- Automounting of snapshots work correctly inside chroot environments (except for `--bind/--rbind` case)

SCALE Build: http://jenkins.eng.ixsystems.net:8080/job/master/job/custom/624/artifact/
API Tests: http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/1413/#showFailuresLink

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
