### PR TITLE
NAS-133615 / None / Revert "Linux: Enable Direct IO by default"

### DIFF
--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -77,15 +77,8 @@ int zfs_bclone_wait_dirty = 0;
  * Enable Direct I/O. If this setting is 0, then all I/O requests will be
  * directed through the ARC acting as though the dataset property direct was
  * set to disabled.
- *
- * Disabled by default on FreeBSD until a potential range locking issue in
- * zfs_getpages() can be resolved.
  */
-#ifdef __FreeBSD__
 static int zfs_dio_enabled = 0;
-#else
-static int zfs_dio_enabled = 1;
-#endif
 
 
 /*


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Reverting Direct IO enablement after encountering kernel panic during NVIDIA driver installation through systemd-sysext (similar to [OpenZFS Issue #16956](https://github.com/openzfs/zfs/issues/16956)). Additionally, multiple upstream bugs have been reported related to Direct IO after its enablement.
- [Block Cloning fallback with O_DIRECT flag causes kernel panic in older kernel versions](https://github.com/openzfs/zfs/issues/16952)
- [Direct IO resulting in Veeam failing "to open storage for read/write access" with direct=standard](https://github.com/openzfs/zfs/issues/16953)
- [Creating a loop device over ZFS file system causes NULL pointer exception when direct=always is set](https://github.com/openzfs/zfs/issues/16956)
- [copy_file_range() returns EAGAIN for direct=always but succeeds for direct=standard on non-recordsize-aligned requests](https://github.com/openzfs/zfs/issues/16958)

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
- CI Testing
- [Scale Build](http://jenkins.eng.ixsystems.net:8080/job/master/job/custom/851/)
- [API Tests](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/2637/console) seems to be failing unrealted to this changeset. Same python exception in recent master/INCREMENTAL as well, @yocalebo:
```
+ sudo ixnode create --iso /data/ISO/api_tests/2634/install.iso --nickname=api_tests__2634 --ha
[Pipeline] sh
+ sudo ixnode boot ha001 --wait
Traceback (most recent call last):
  File "/usr/local/bin/ixnode", line 33, in <module>
    sys.exit(load_entry_point('ixnode==0.1.2', 'console_scripts', 'ixnode')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/ixnode-0.1.2-py3.11.egg/ixnode/ixnode.py", line 1598, in main
  File "/usr/local/lib/python3.11/dist-packages/ixnode-0.1.2-py3.11.egg/ixnode/ixnode.py", line 1025, in ixnode_boot
  File "/usr/local/lib/python3.11/dist-packages/ixnode-0.1.2-py3.11.egg/ixnode/expect.py", line 242, in wait_for_boot
  File "/usr/lib/python3/dist-packages/pexpect/spawnbase.py", line 343, in expect
    return self.expect_list(compiled_pattern_list,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/pexpect/spawnbase.py", line 372, in expect_list
    return exp.expect_loop(timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/pexpect/expect.py", line 181, in expect_loop
    return self.timeout(e)
           ^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/pexpect/expect.py", line 144, in timeout
    raise exc
pexpect.exceptions.TIMEOUT: Timeout exceeded.
<pexpect.pty_spawn.spawn object at 0x7f90055bb710>
command: /usr/bin/virsh
args: ['/usr/bin/virsh', 'console', 'ha001_c1']
buffer (last 100 chars): b' 42, in _create_arguments\r\n    if item["type"] != "object":\r\n       ~~~~^^^^^^^^\r\nKeyError: \'type\'\r\n'
before (last 100 chars): b' 42, in _create_arguments\r\n    if item["type"] != "object":\r\n       ~~~~^^^^^^^^\r\nKeyError: \'type\'\r\n'
after: <class 'pexpect.exceptions.TIMEOUT'>
``` 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
