### PR TITLE
[release/25.04.1] Backport Critical ARC Fixes by Mav

### DIFF
--- a/include/os/linux/kernel/linux/page_compat.h
+++ b/include/os/linux/kernel/linux/page_compat.h
@@ -4,8 +4,8 @@
 /*
  * Create our own accessor functions to follow the Linux API changes
  */
-#define	nr_file_pages() global_node_page_state(NR_FILE_PAGES)
-#define	nr_inactive_anon_pages() global_node_page_state(NR_INACTIVE_ANON)
+#define	nr_file_pages() (global_node_page_state(NR_ACTIVE_FILE) + \
+			global_node_page_state(NR_INACTIVE_FILE))
 #define	nr_inactive_file_pages() global_node_page_state(NR_INACTIVE_FILE)
 
 #endif /* _ZFS_PAGE_COMPAT_H */

--- a/include/sys/dbuf.h
+++ b/include/sys/dbuf.h
@@ -445,6 +445,7 @@ int dbuf_dnode_findbp(dnode_t *dn, uint64_t level, uint64_t blkid,
 
 void dbuf_init(void);
 void dbuf_fini(void);
+void dbuf_cache_reduce_target_size(void);
 
 boolean_t dbuf_is_metadata(dmu_buf_impl_t *db);
 

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -861,7 +861,9 @@ pressure on the pagecache, yet still allows the ARC to be reclaimed down to
 .Sy zfs_arc_min
 if necessary.
 This value is specified as percent of pagecache size (as measured by
-.Sy NR_FILE_PAGES ) ,
+.Sy NR_ACTIVE_FILE
++
+.Sy NR_INACTIVE_FILE ) ,
 where that percent may exceed
 .Sy 100 .
 This

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -296,6 +296,7 @@
 #include <sys/dsl_pool.h>
 #include <sys/multilist.h>
 #include <sys/abd.h>
+#include <sys/dbuf.h>
 #include <sys/zil.h>
 #include <sys/fm/fs/zfs.h>
 #include <sys/callb.h>
@@ -4438,6 +4439,13 @@ arc_reduce_target_size(uint64_t to_free)
 	} else {
 		to_free = 0;
 	}
+
+	/*
+	 * Since dbuf cache size is a fraction of target ARC size, we should
+	 * notify dbuf about the reduction, which might be significant,
+	 * especially if current ARC size was much smaller than the target.
+	 */
+	dbuf_cache_reduce_target_size();
 
 	/*
 	 * Whether or not we reduced the target size, request eviction if the

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -4199,15 +4199,17 @@ static uint64_t
 arc_evict_adj(uint64_t frac, uint64_t total, uint64_t up, uint64_t down,
     uint_t balance)
 {
-	if (total < 8 || up + down == 0)
+	if (total < 32 || up + down == 0)
 		return (frac);
 
 	/*
-	 * We should not have more ghost hits than ghost size, but they
-	 * may get close.  Restrict maximum adjustment in that case.
+	 * We should not have more ghost hits than ghost size, but they may
+	 * get close.  To avoid overflows below up/down should not be bigger
+	 * than 1/5 of total.  But to limit maximum adjustment speed restrict
+	 * it some more.
 	 */
-	if (up + down >= total / 4) {
-		uint64_t scale = (up + down) / (total / 8);
+	if (up + down >= total / 16) {
+		uint64_t scale = (up + down) / (total / 32);
 		up /= scale;
 		down /= scale;
 	}
@@ -4216,6 +4218,7 @@ arc_evict_adj(uint64_t frac, uint64_t total, uint64_t up, uint64_t down,
 	int s = highbit64(total);
 	s = MIN(64 - s, 32);
 
+	ASSERT3U(frac, <=, 1ULL << 32);
 	uint64_t ofrac = (1ULL << 32) - frac;
 
 	if (frac >= 4 * ofrac)
@@ -4226,6 +4229,8 @@ arc_evict_adj(uint64_t frac, uint64_t total, uint64_t up, uint64_t down,
 	down = (down << s) / (total >> (32 - s));
 	down = down * 100 / balance;
 
+	ASSERT3U(up, <=, (1ULL << 32) - frac);
+	ASSERT3U(down, <=, frac);
 	return (frac + up - down);
 }
 

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -871,6 +871,19 @@ dbuf_evict_notify(uint64_t size)
 	}
 }
 
+/*
+ * Since dbuf cache size is a fraction of target ARC size, ARC calls this when
+ * its target size is reduced due to memory pressure.
+ */
+void
+dbuf_cache_reduce_target_size(void)
+{
+	uint64_t size = zfs_refcount_count(&dbuf_caches[DB_DBUF_CACHE].size);
+
+	if (size > dbuf_cache_target_bytes())
+		cv_signal(&dbuf_evict_cv);
+}
+
 static int
 dbuf_kstat_update(kstat_t *ksp, int rw)
 {


### PR DESCRIPTION
### Motivation and Context
- Backport critical ARC patches for next hot-fix.

### Description
- Use evictable page cache for ARC scaling to avoid Qemu Crash
- Notify dbuf cache about target size reduction
- Limits maximum balance adjustment speed

### How Has This Been Tested?
- CI Testing (ZTS failing on Fedora VM due to unsupported kernel version)
- [Scale Build](http://jenkins.eng.ixsystems.net:8080/job/fangtooth/job/custom/29/)

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
