### PR TITLE
NAS-135951 / 25.10 / Expose dataset encryption status via fast stat path

### DIFF
--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -591,6 +591,7 @@ _LIBZFS_H int zfs_crypto_attempt_load_keys(libzfs_handle_t *, const char *);
 _LIBZFS_H int zfs_crypto_load_key(zfs_handle_t *, boolean_t, const char *);
 _LIBZFS_H int zfs_crypto_unload_key(zfs_handle_t *);
 _LIBZFS_H int zfs_crypto_rewrap(zfs_handle_t *, nvlist_t *, boolean_t);
+_LIBZFS_H boolean_t zfs_is_encrypted(zfs_handle_t *);
 
 typedef struct zprop_list {
 	int		pl_prop;

--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -997,6 +997,11 @@ void dmu_object_size_from_db(dmu_buf_t *db, uint32_t *blksize,
 
 void dmu_object_dnsize_from_db(dmu_buf_t *db, int *dnsize);
 
+typedef enum {
+	DDS_FLAG_ENCRYPTED = (1<<0),
+	DDS_FLAG_HAS_ENCRYPTED = (1<<7),
+} dmu_objset_flag_t;
+
 typedef struct dmu_objset_stats {
 	uint64_t dds_num_clones; /* number of clones of this */
 	uint64_t dds_creation_txg;
@@ -1006,6 +1011,7 @@ typedef struct dmu_objset_stats {
 	uint8_t dds_inconsistent;
 	uint8_t dds_redacted;
 	char dds_origin[ZFS_MAX_DATASET_NAME_LEN];
+	uint8_t dds_flags; /* dmu_objset_flag_t */
 } dmu_objset_stats_t;
 
 /*

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -345,6 +345,7 @@
     <elf-symbol name='zfs_hold' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_hold_nvl' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_ioctl' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_is_encrypted' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_is_mounted' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_is_shared' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_isnumber' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -1919,6 +1920,9 @@
       </data-member>
       <data-member access='public' layout-offset-in-bits='248'>
         <var-decl name='dds_origin' type-id='d1617432' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2296'>
+        <var-decl name='dds_flags' type-id='b96825af' visibility='default'/>
       </data-member>
     </class-decl>
     <typedef-decl name='dmu_objset_stats_t' type-id='098f0221' id='b2c14f17'/>
@@ -3820,6 +3824,10 @@
       <parameter type-id='5ce45b60' name='raw_props'/>
       <parameter type-id='c19b74c3' name='inheritkey'/>
       <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_is_encrypted' mangled-name='zfs_is_encrypted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_encrypted'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <return type-id='c19b74c3'/>
     </function-decl>
     <function-decl name='zfs_error_aux' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='b0382bb3'/>

--- a/lib/libzfs/libzfs_crypto.c
+++ b/lib/libzfs/libzfs_crypto.c
@@ -1818,3 +1818,14 @@ error:
 	zfs_error(zhp->zfs_hdl, EZFS_CRYPTOFAILED, errbuf);
 	return (ret);
 }
+
+boolean_t
+zfs_is_encrypted(zfs_handle_t *zhp)
+{
+	uint8_t flags = zhp->zfs_dmustats.dds_flags;
+
+	if (flags & DDS_FLAG_HAS_ENCRYPTED)
+		return ((flags & DDS_FLAG_ENCRYPTED) != 0);
+
+	return (zfs_prop_get_int(zhp, ZFS_PROP_ENCRYPTION) != ZIO_CRYPT_OFF);
+}

--- a/lib/libzfs_core/libzfs_core.abi
+++ b/lib/libzfs_core/libzfs_core.abi
@@ -1494,6 +1494,9 @@
       <data-member access='public' layout-offset-in-bits='248'>
         <var-decl name='dds_origin' type-id='d1617432' visibility='default'/>
       </data-member>
+      <data-member access='public' layout-offset-in-bits='2296'>
+        <var-decl name='dds_flags' type-id='b96825af' visibility='default'/>
+      </data-member>
     </class-decl>
     <typedef-decl name='dmu_objset_stats_t' type-id='098f0221' id='b2c14f17'/>
     <enum-decl name='dmu_objset_type' id='6b1b19f9'>

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -2881,6 +2881,9 @@ dsl_dataset_fast_stat(dsl_dataset_t *ds, dmu_objset_stats_t *stat)
 	stat->dds_guid = dsl_get_guid(ds);
 	stat->dds_redacted = dsl_get_redacted(ds);
 	stat->dds_origin[0] = '\0';
+	stat->dds_flags = DDS_FLAG_HAS_ENCRYPTED;
+	if (ds->ds_dir->dd_crypto_obj != 0)
+		stat->dds_flags |= DDS_FLAG_ENCRYPTED;
 	if (ds->ds_is_snapshot) {
 		stat->dds_is_snapshot = B_TRUE;
 		stat->dds_num_clones = dsl_get_numclones(ds);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In truenas_pylibzfs, we query list of encrypted datasets several times, which is expensive. This commit exposes a public API zfs_is_encrypted() to get encryption status from fast stat path without having to refresh the properties.

Reviewed-by: Brian Behlendorf <behlendorf1@llnl.gov>
Reviewed-by: Alexander Motin <mav@FreeBSD.org>
Reviewed-by: Rob Norris <robn@despairlabs.com>

Closes #17368

### Description
<!--- Describe your changes in detail -->
This change adds a new field, `dds_flags`, to the `dmu_objset_stats` structure. The field is inserted into the existing padding after `dds_origin` and does not increase the structure size or alter the position of existing members. This ensures backward compatibility between kernel and user-space consumers of `dmu_objset_stats`, such as `zfs_cmd_t` used by IOCTLs.

**Before this commit:**
```
hamza@~/zfs-debug (master) $ pahole -C dmu_objset_stats module/zfs.ko
struct dmu_objset_stats {
	uint64_t                   dds_num_clones;       /*     0     8 */
	uint64_t                   dds_creation_txg;     /*     8     8 */
	uint64_t                   dds_guid;             /*    16     8 */
	dmu_objset_type_t          dds_type;             /*    24     4 */
	uint8_t                    dds_is_snapshot;      /*    28     1 */
	uint8_t                    dds_inconsistent;     /*    29     1 */
	uint8_t                    dds_redacted;         /*    30     1 */
	char                       dds_origin[256];      /*    31   256 */

	/* size: 288, cachelines: 5, members: 8 */
	/* padding: 1 */
	/* last cacheline: 32 bytes */
};
```
**After this commit:**
```
hamza@~/zfs (NAS-135951-ge) $ pahole -C dmu_objset_stats module/zfs.ko
struct dmu_objset_stats {
	uint64_t                   dds_num_clones;       /*     0     8 */
	uint64_t                   dds_creation_txg;     /*     8     8 */
	uint64_t                   dds_guid;             /*    16     8 */
	dmu_objset_type_t          dds_type;             /*    24     4 */
	uint8_t                    dds_is_snapshot;      /*    28     1 */
	uint8_t                    dds_inconsistent;     /*    29     1 */
	uint8_t                    dds_redacted;         /*    30     1 */
	char                       dds_origin[256];      /*    31   256 */
	/* --- cacheline 4 boundary (256 bytes) was 31 bytes ago --- */
	uint8_t                    dds_flags;            /*   287     1 */

	/* size: 288, cachelines: 5, members: 9 */
	/* last cacheline: 32 bytes */
};
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
- Manually invoked `zfs_is_encrypted()` in `zfs_main.c` to validate that it returns the correct encryption status.
- CI Testing
- [Scale Build](http://jenkins.eng.ixsystems.net:8080/job/master/job/custom/1121)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
