### PR TITLE
NAS-137531 / 26.04 / Disable nfs smb sharing

### DIFF
--- a/lib/libshare/libshare_impl.h
+++ b/lib/libshare/libshare_impl.h
@@ -27,6 +27,7 @@
  */
 #ifndef _LIBSPL_LIBSHARE_IMPL_H
 #define	_LIBSPL_LIBSHARE_IMPL_H
+#include <sys/stdtypes.h>	/* boolean_t */
 
 typedef const struct sa_share_impl {
 	const char *sa_zfsname;

--- a/lib/libshare/os/linux/nfs.c
+++ b/lib/libshare/os/linux/nfs.c
@@ -559,6 +559,7 @@ const sa_fstype_t libshare_nfs_type = {
 static boolean_t
 nfs_available(void)
 {
+#ifdef TRUENAS_ENABLE_ZFS_SHARING
 	static int avail;
 
 	if (!avail) {
@@ -569,11 +570,15 @@ nfs_available(void)
 	}
 
 	return (avail == 1);
+#else
+	return (B_FALSE);
+#endif
 }
 
 static boolean_t
 exports_available(void)
 {
+#ifdef TRUENAS_ENABLE_ZFS_SHARING
 	static int avail;
 
 	if (!avail) {
@@ -584,4 +589,7 @@ exports_available(void)
 	}
 
 	return (avail == 1);
+#else
+	return (B_FALSE);
+#endif
 }

--- a/lib/libshare/os/linux/smb.c
+++ b/lib/libshare/os/linux/smb.c
@@ -390,6 +390,7 @@ const sa_fstype_t libshare_smb_type = {
 static boolean_t
 smb_available(void)
 {
+#ifdef TRUENAS_ENABLE_ZFS_SHARING
 	static int avail;
 
 	if (!avail) {
@@ -404,4 +405,8 @@ smb_available(void)
 	}
 
 	return (avail == 1);
+#else
+	/* TrueNAS: Disable SMB sharing */
+	return (B_FALSE);
+#endif
 }

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -335,12 +335,13 @@ tests = ['cache_001_pos', 'cache_002_neg', 'canmount_001_pos',
     'zfs_set_feature_activation', 'zfs_set_nomount']
 tags = ['functional', 'cli_root', 'zfs_set']
 
-[tests/functional/cli_root/zfs_share]
-tests = ['zfs_share_001_pos', 'zfs_share_002_pos', 'zfs_share_003_pos',
-    'zfs_share_004_pos', 'zfs_share_006_pos', 'zfs_share_008_neg',
-    'zfs_share_010_neg', 'zfs_share_011_pos', 'zfs_share_concurrent_shares',
-    'zfs_share_after_mount']
-tags = ['functional', 'cli_root', 'zfs_share']
+# TrueNAS: Disable share tests
+# [tests/functional/cli_root/zfs_share]
+# tests = ['zfs_share_001_pos', 'zfs_share_002_pos', 'zfs_share_003_pos',
+#     'zfs_share_004_pos', 'zfs_share_006_pos', 'zfs_share_008_neg',
+#     'zfs_share_010_neg', 'zfs_share_011_pos', 'zfs_share_concurrent_shares',
+#     'zfs_share_after_mount']
+# tags = ['functional', 'cli_root', 'zfs_share']
 
 [tests/functional/cli_root/zfs_snapshot]
 tests = ['zfs_snapshot_001_neg', 'zfs_snapshot_002_neg',
@@ -360,11 +361,12 @@ tests = ['zfs_unmount_001_pos', 'zfs_unmount_002_pos', 'zfs_unmount_003_pos',
     'zfs_unmount_all_001_pos', 'zfs_unmount_nested', 'zfs_unmount_unload_keys']
 tags = ['functional', 'cli_root', 'zfs_unmount']
 
-[tests/functional/cli_root/zfs_unshare]
-tests = ['zfs_unshare_001_pos', 'zfs_unshare_002_pos', 'zfs_unshare_003_pos',
-    'zfs_unshare_004_neg', 'zfs_unshare_005_neg', 'zfs_unshare_006_pos',
-    'zfs_unshare_007_pos']
-tags = ['functional', 'cli_root', 'zfs_unshare']
+# TrueNAS: Disable unshare tests
+# [tests/functional/cli_root/zfs_unshare]
+# tests = ['zfs_unshare_001_pos', 'zfs_unshare_002_pos', 'zfs_unshare_003_pos',
+#     'zfs_unshare_004_neg', 'zfs_unshare_005_neg', 'zfs_unshare_006_pos',
+#     'zfs_unshare_007_pos']
+# tags = ['functional', 'cli_root', 'zfs_unshare']
 
 [tests/functional/cli_root/zfs_upgrade]
 tests = ['zfs_upgrade_001_pos', 'zfs_upgrade_002_pos', 'zfs_upgrade_003_pos',

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -53,14 +53,16 @@ tests = ['zfs_mount_006_pos', 'zfs_mount_008_pos', 'zfs_mount_013_pos',
     'zfs_mount_014_neg', 'zfs_multi_mount']
 tags = ['functional', 'cli_root', 'zfs_mount']
 
-[tests/functional/cli_root/zfs_share:Linux]
-tests = ['zfs_share_005_pos', 'zfs_share_007_neg', 'zfs_share_009_neg',
-    'zfs_share_012_pos', 'zfs_share_013_pos']
-tags = ['functional', 'cli_root', 'zfs_share']
+# TrueNAS: Disable share tests
+# [tests/functional/cli_root/zfs_share:Linux]
+# tests = ['zfs_share_005_pos', 'zfs_share_007_neg', 'zfs_share_009_neg',
+#     'zfs_share_012_pos', 'zfs_share_013_pos']
+# tags = ['functional', 'cli_root', 'zfs_share']
 
-[tests/functional/cli_root/zfs_unshare:Linux]
-tests = ['zfs_unshare_008_pos']
-tags = ['functional', 'cli_root', 'zfs_unshare']
+# TrueNAS: Disable unshare tests
+# [tests/functional/cli_root/zfs_unshare:Linux]
+# tests = ['zfs_unshare_008_pos']
+# tags = ['functional', 'cli_root', 'zfs_unshare']
 
 [tests/functional/cli_root/zfs_sysfs:Linux]
 tests = ['zfeature_set_unsupported', 'zfs_get_unsupported',

--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -140,6 +140,9 @@ if sys.platform.startswith('freebsd'):
 else:
     cfr_cross_reason = 'copy_file_range(2) cross-filesystem needs kernel 5.3+'
 
+# TrueNAS
+truenas_skip = 'SKIP: Test not supported in TrueNAS'
+
 #
 # These tests are known to fail, thus we use this list to prevent these
 # failures from failing the job as a whole; only unexpected failures
@@ -164,6 +167,7 @@ known = {
     'rootpool/setup': ['SKIP', na_reason],
     'rsend/rsend_008_pos': ['SKIP', 6066],
     'vdev_zaps/vdev_zaps_007_pos': ['FAIL', known_reason],
+    'cli_root/zpool_import/zpool_import_012_pos': ['SKIP', truenas_skip],
 }
 
 if sys.platform.startswith('freebsd'):

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_set/canmount_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_set/canmount_002_pos.ksh
@@ -121,7 +121,8 @@ while (( i < ${#dataset_pos[*]} )) ; do
 	dataset=${dataset_pos[i]}
 	set_n_check_prop "noauto" "canmount" "$dataset"
 	log_must zfs set mountpoint=$tmpmnt $dataset
-	log_must zfs set sharenfs=on $dataset
+	# TrueNAS: sharenfs disabled and cannot test with log_must or log_mustnot
+	# log_must zfs set sharenfs=on $dataset
 	if ismounted $dataset; then
 		zfs unmount -a > /dev/null 2>&1
 		log_must mounted $dataset
@@ -129,8 +130,8 @@ while (( i < ${#dataset_pos[*]} )) ; do
 		log_must unmounted $dataset
 		log_must zfs mount -a
 		log_must unmounted $dataset
-		log_must zfs share -a
-		log_mustnot is_exported $tmpmnt
+		# log_must zfs share -a	# TrueNAS: Do not share via ZFS
+		# log_mustnot is_exported $tmpmnt # TrueNAS: avoid false failure
 	else
 		log_must zfs mount -a
 		log_must unmounted $dataset
@@ -140,9 +141,10 @@ while (( i < ${#dataset_pos[*]} )) ; do
 
 	log_must zfs mount $dataset
 	log_must mounted $dataset
-	log_must zfs share -a
-	log_must is_exported $tmpmnt
+	# log_must zfs share -a	# TrueNAS: Do not share via ZFS
+	# log_must is_exported $tmpmnt	# TrueNAS: avoid false failure
 
+	# TrueNAS: set of sharenfs property tested here
 	log_must zfs set sharenfs="${old_sharenfs[i]}" $dataset
 	log_must zfs set canmount="${old_canmount[i]}" $dataset
 	log_must zfs set mountpoint="${old_mnt[i]}" $dataset

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_012_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_012_pos.ksh
@@ -52,6 +52,8 @@
 
 verify_runnable "global"
 
+log_unsupported "SKIP: sharenfs is disabled on TrueNAS"
+
 set -A pools "$TESTPOOL" "$TESTPOOL1"
 set -A devs "" "-d $DEVICE_DIR"
 set -A options "" "-R $ALTER_ROOT"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->
Disable ZFS `sharenfs` and `sharesmg`
<!--- Provide a general summary of your changes in the Title above -->
This is TrueNAS specific.  TrueNAS tightly manages SMB and NFS sharing.  Any other methods for share configuration will cause failures on the server and TrueNAS server management.
To prevent this scenario this PR disables NFS and SMB sharing via ZFS.

Also added an #include statement to `libshare_impl.h` so that it and modules using it would have the definition of `boolean_t`

This change may possibly break any ZFS tests that require function `sharenfs` and `sharesmb`.
<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This has historically been an issue for TrueNAS and much middleware code has been added to squash and repair instances of ZFS share configuration.
The CI test `test_004_verify_pool_property_unused_disk_functionality` in `test_006_pool_and_sysds.py` has been consistently failing a `sharenfs` test.
### Description
<!--- Describe your changes in detail -->
In both `lib/libshare/os/linux/nfs.c` and `lib/libshare/os/linux/smb.c` wrapped the implementation of `nfs_available(void)` and `smb_available(void)` with an `#ifdef TRUENAS_ENABLE_ZFS_SHARING` with an `#else` clause being `return (B_FALSE)`.
This effectively disables SMB and NFS sharing via ZFS.
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Did a build and allowed the CI tests to run:  http://jenkins.eng.ixsystems.net:8080/job/master/job/custom/1506/
Also spun up single and HA VMs with the build and did manual testing.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x ] Code cleanup (non-breaking change which makes code smaller or more readable) 
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
