### PR TITLE
NAS-138001 / 27.0.0-BETA.1 / Fix MS_CRYPT flag usage on zfs_unmountall

### DIFF
--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -666,10 +666,27 @@ int
 zfs_unmountall(zfs_handle_t *zhp, int flags)
 {
 	prop_changelist_t *clp;
+	int gather_flags = 0;
 	int ret;
 
+	/*
+	 * Historically CL_GATHER_ITER_MOUNTED was always set here, which uses
+	 * zfs_iter_mounted() and at the end of the day zfs_umount() each
+	 * mounted child that inherits the mountpoint property from the
+	 * filesystem specified by zhp.
+	 *
+	 * When MS_CRYPT is specified in flags for safety sake we extend
+	 * behavior of zfs_umount() to call zfs_unmount() on all child
+	 * filesystems that inherit the mountpoint property (regardless of they
+	 * they are mounted or not). This ensures that the encryption keys for
+	 * all encryption roots in child filesystems are unloaded whether they
+	 * are mounted or not.
+	 */
+	if ((flags & MS_CRYPT) == 0)
+		gather_flags |= CL_GATHER_ITER_MOUNTED;
+
 	clp = changelist_gather(zhp, ZFS_PROP_MOUNTPOINT,
-	    CL_GATHER_ITER_MOUNTED, flags);
+	    gather_flags, flags);
 	if (clp == NULL)
 		return (-1);
 

--- a/man/man8/zfs-mount.8
+++ b/man/man8/zfs-mount.8
@@ -131,7 +131,10 @@ Invoked automatically as part of the shutdown process.
 Forcefully unmount the file system, even if it is currently in use.
 This option is not supported on Linux.
 .It Fl u
-Unload keys for any encryption roots unmounted by this command.
+Unload keys for any encryption roots unmounted by this command. If a child
+filesystem of a target of this command inherits its mountpoint property from
+it, then its key will also be unloaded.
+regardless of mounted status.
 .It Ar filesystem Ns | Ns Ar mountpoint
 Unmount the specified filesystem.
 The command can also be given a path to a ZFS file system mount point on the

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_unmount/zfs_unmount_unload_keys.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_unmount/zfs_unmount_unload_keys.ksh
@@ -52,13 +52,18 @@ function cleanup
 		destroy_dataset $TESTPOOL/$TESTFS2/newroot -r
 	datasetexists $TESTPOOL/$TESTFS2/child && \
 		destroy_dataset $TESTPOOL/$TESTFS2/child -r
-
+	datasetexists $TESTPOOL/$TESTFS3 && \
+		destroy_dataset $TESTPOOL/$TESTFS3 -r
+	datasetexists $TESTPOOL/$TESTFS3/child && \
+		destroy_dataset $TESTPOOL/$TESTFS3/child -r
 }
 log_onexit cleanup
 
 log_assert "'zfs unmount -u' should unload keys for datasets as they are unmounted"
 log_must eval "echo 'password' | zfs create -o encryption=on -o keyformat=passphrase $TESTPOOL/$TESTFS2"
 log_must eval "echo 'password' | zfs create -o encryption=on -o keyformat=passphrase $TESTPOOL/$TESTFS2/newroot"
+log_must eval "echo 'password' | zfs create -o encryption=on -o keyformat=passphrase $TESTPOOL/$TESTFS3"
+log_must eval "echo 'password' | zfs create -o encryption=on -o keyformat=passphrase $TESTPOOL/$TESTFS3/child"
 log_must zfs create $TESTPOOL/$TESTFS2/child
 
 log_must zfs umount -u $TESTPOOL/$TESTFS2/newroot
@@ -76,5 +81,11 @@ log_must zfs clone $TESTPOOL/$TESTFS2/newroot@1 $TESTPOOL/$TESTFS2/clone
 log_mustnot zfs umount -u $TESTPOOL/$TESTFS2/newroot
 log_must key_available $TESTPOOL/$TESTFS2/newroot
 log_must mounted $TESTPOOL/$TESTFS2/newroot
+
+log_must zfs umount $TESTPOOL/$TESTFS3/child
+log_must key_available $TESTPOOL/$TESTFS3/child
+log_must zfs umount -u $TESTPOOL/$TESTFS3
+log_must key_unavailable $TESTPOOL/$TESTFS3
+log_must key_unavailable $TESTPOOL/$TESTFS3/child
 
 log_pass "'zfs unmount -u' unloads keys for datasets as they are unmounted"


### PR DESCRIPTION
This commit ensures that MS_CRYPT flag on recursive unmount is applied to all dependent datasets.

The behavior of zfs_umount() is when MS_CRYPT flag is passed then the encryption key is automatically unloaded even if the dataset is already unmounted.

When zfs_unmountall is called this behavior is not currently propagated properly to child filesystems resulting in potentially inconsistent unloading of the encryption keys on them (depending on whether the dataset is currently in the mtab). This makes it so that actual behavior of zfs unmount -u is unpredictable from an administrative perspective.

Prior to this change if you have the following hierarchy: 
Case 1
- dozer/ds1 (encypted / mounted / loaded (encroot1))
- dozer/ds1/ds2 (encypted / unmounted / loaded (encroot2))

Case 2
- dozer/ds1 (encypted / mounted / loaded (encroot1))
- dozer/ds1/ds2 (encypted / mounted / loaded (encroot2))

"zfs unmount -u dozer/ds1" will leave the key in dozer/ds1/ds2 loaded in case 1, but unload in case 2.

After this change, the key is unloaded in both cases