### PR TITLE
NAS-138673 / 26.04 / Add symlinks for renamed arc tools

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -107,6 +107,17 @@ $(call SUBST,dbufstat,%D%/)
 $(call SUBST,zilstat,%D%/)
 zarcsummary: %D%/zarcsummary
 	$(AM_V_at)cp $< $@
+
+# NAS-138673: Create backward compatibility symlinks for renamed zarcsummary
+# and zarcstat tools (previously arc_summary and arcstat)
+install-exec-hook:
+	$(MKDIR_P) $(DESTDIR)$(sbindir)
+	$(LN_S) -f $(bindir)/zarcstat $(DESTDIR)$(sbindir)/arcstat
+	$(LN_S) -f $(bindir)/zarcsummary $(DESTDIR)$(sbindir)/arc_summary
+
+uninstall-hook:
+	$(RM) $(DESTDIR)$(sbindir)/arcstat
+	$(RM) $(DESTDIR)$(sbindir)/arc_summary
 endif
 
 PHONY += cmd

--- a/contrib/debian/openzfs-zfsutils.install
+++ b/contrib/debian/openzfs-zfsutils.install
@@ -40,6 +40,8 @@ usr/bin/zarcsummary
 usr/bin/zarcstat
 usr/bin/dbufstat usr/sbin
 usr/bin/zilstat
+usr/sbin/arc_summary
+usr/sbin/arcstat
 usr/share/zfs/compatibility.d/
 usr/share/bash-completion/completions
 usr/share/man/man1/zarcstat.1


### PR DESCRIPTION
### Motivation and Context
[Upstream renamed](https://github.com/openzfs/zfs/pull/17712) `arc_summary`/`arcstat` to `zarcsummary`/`zarcstat` in 2.4.0 to avoid namespace collision with `nordugrid-arc-client` tool. This breaks existing scripts, ixdiagnose, documentation, and support workflows.

### Description
<!--- Describe your changes in detail -->
Since `nordugrid-arc-client` tool is not used in TrueNAS, add backward compatibility symlinks at `/usr/sbin/arcstat` and `/usr/sbin/arc_summary` pointing to the new tool names. This allows both old and new names to work, avoiding disruption to existing workflows.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Tested with [Custom Scale Build](http://jenkins.eng.ixsystems.net:8080/job/master/job/custom/1755/artifact/): 
```
root@truenas[~]# which arcstat
/usr/sbin/arcstat
root@truenas[~]# which zarcstat
/usr/bin/zarcstat
root@truenas[~]# ls -l /usr/sbin/arc_summary 
lrwxrwxrwx 1 root root 18 Dec 10 04:37 /usr/sbin/arc_summary -> ../bin/zarcsummary
root@truenas[~]# arcstat | head -5     
    time  read  ddread  ddh%  dmread  dmh%  pread  ph%   size      c  avail
05:42:02     0       0     0       0     0      0    0   3.9G   4.0G  24.2G
root@truenas[~]# zarcstat | head -5
    time  read  ddread  ddh%  dmread  dmh%  pread  ph%   size      c  avail
05:42:08     0       0     0       0     0      0    0   3.9G   4.0G  24.2G
root@truenas[~]# which arc_summary
/usr/sbin/arc_summary
root@truenas[~]# which zarcsummary 
/usr/bin/zarcsummary
root@truenas[~]# ls -l /usr/sbin/arcstat    
lrwxrwxrwx 1 root root 15 Dec 10 04:37 /usr/sbin/arcstat -> ../bin/zarcstat
root@truenas[~]# arc_summary| head -5

------------------------------------------------------------------------
ZFS Subsystem Report                            Wed Dec 10 05:42:46 2025
Linux 6.18.0-production+truenas                                2.4.0-rc4
Machine: truenas (x86_64)                                      2.4.0-rc4
root@truenas[~]# zarcsummary| head -5 

------------------------------------------------------------------------
ZFS Subsystem Report                            Wed Dec 10 05:42:52 2025
Linux 6.18.0-production+truenas                                2.4.0-rc4
Machine: truenas (x86_64)                                      2.4.0-rc4
root@truenas[~]# uname -r
6.18.0-production+truenas
```


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
