### PR TITLE
Add handling for STATX_CHANGE_COOKIE

### DIFF
--- a/module/os/linux/zfs/zpl_inode.c
+++ b/module/os/linux/zfs/zpl_inode.c
@@ -506,6 +506,14 @@ zpl_getattr_impl(const struct path *path, struct kstat *stat, u32 request_mask,
 	}
 #endif
 
+#ifdef STATX_CHANGE_COOKIE
+	if (request_mask & STATX_CHANGE_COOKIE) {
+		stat->change_cookie = zp->z_seq;
+		stat->attributes |= STATX_ATTR_CHANGE_MONOTONIC;
+		stat->result_mask |= STATX_CHANGE_COOKIE;
+	}
+#endif
+
 #ifdef STATX_DIOALIGN
 	if (request_mask & STATX_DIOALIGN) {
 		uint64_t align;


### PR DESCRIPTION
This commit adds handling for the `STATX_CHANGE_COOKIE` so that we can properly surface the ZFS znode sequence number to NFS clients via knfsd.

If knfsd does not have `STATX_CHANGE_COOKIE` in statx result then it will synthesize the NFS change_info4 structure and related change4id values algorithmically based on the ctime value of the file. Since internally ZFS is using `ktime_get_coarse_real_ts64()` for the timestamp calculation here it introduces the possibility that the change will not increment the change4id of directories / files causing a failure in the client to invalidate its attr cache (among other things).

Notable in this commit is that we are not initializing `the inode->i_version` to the `znode->z_seq` number. The reason for this is that we're intentionally not setting `SB_I_VERSION`. This indicates that the filesystem manages its own i_version and so it is not populated in the generic_fillattr.
