### PR TITLE
NAS-138343 / 26.04 / Fix handling for ACE_WRITE_OWNER and ACE_WRITE_ACL

### DIFF
--- a/module/os/linux/zfs/policy.c
+++ b/module/os/linux/zfs/policy.c
@@ -197,9 +197,6 @@ secpolicy_vnode_any_access(const cred_t *cr, struct inode *ip, uid_t owner)
 int
 secpolicy_vnode_chown(const cred_t *cr, uid_t owner)
 {
-	if (crgetuid(cr) == owner)
-		return (0);
-
 #if defined(CONFIG_USER_NS)
 	if (!kuid_has_mapping(cr->user_ns, SUID_TO_KUID(owner)))
 		return (EPERM);
@@ -382,6 +379,9 @@ secpolicy_setid_setsticky_clear(struct inode *ip, vattr_t *vap,
 int
 secpolicy_xvattr(xvattr_t *xvap, uid_t owner, cred_t *cr, mode_t type)
 {
+	if (crgetuid(cr) == owner)
+		return (0);
+
 	return (secpolicy_vnode_chown(cr, owner));
 }
 

--- a/module/os/linux/zfs/zfs_acl.c
+++ b/module/os/linux/zfs/zfs_acl.c
@@ -2428,12 +2428,26 @@ zfs_zaccess_aces_check(znode_t *zp, uint32_t *working_mode,
 		    (iflags & ACE_INHERIT_ONLY_ACE))
 			continue;
 
+		entry_type = (iflags & ACE_TYPE_FLAGS);
+		if ((entry_type == ACE_OWNER || entry_type == OWNING_GROUP ||
+		    entry_type == ACE_EVERYONE) && (type == ALLOW)) {
+			/*
+			 * Reduce access granted by owner, group, and everyone
+			 * entries to not include the ability to change the
+			 * owner or ACL.
+			 * This is to prevent elevation of permissions on file
+			 * beyond what would be normally granted by the file's
+			 * mode. This still allows users with CAP_FOWNER
+			 * or with explicit entry (GROUP or USER entry) to
+			 * modify the owner or ACL.
+			 */
+			access_mask &= ~(ACE_WRITE_ACL | ACE_WRITE_OWNER);
+		}
+
 		/* Skip ACE if it does not affect any AoI */
 		mask_matched = (access_mask & *working_mode);
 		if (!mask_matched)
 			continue;
-
-		entry_type = (iflags & ACE_TYPE_FLAGS);
 
 		checkit = B_FALSE;
 
@@ -2838,8 +2852,20 @@ zfs_zaccess(znode_t *zp, int mode, int flags, boolean_t skipaclchk, cred_t *cr,
 
 		if (error == 0 && (working_mode & ACE_WRITE_OWNER))
 			error = secpolicy_vnode_chown(cr, owner);
-		if (error == 0 && (working_mode & ACE_WRITE_ACL))
-			error = secpolicy_vnode_setdac(cr, owner);
+
+		if (error == 0 && (working_mode & ACE_WRITE_ACL)) {
+			/*
+			 * For a non-trivial ACL write-acl override implies
+			 * ability to write the owner of a file (since user
+			 * can grant self ACE_WRITE_OWNER. This means that
+			 * we need to check chown policy.
+			 */
+
+			if (zp->z_pflags & ZFS_ACL_TRIVIAL)
+				error = secpolicy_vnode_setdac(cr, owner);
+			else
+				error = secpolicy_vnode_chown(cr, owner);
+		}
 
 		if (error == 0 && (working_mode &
 		    (ACE_DELETE|ACE_DELETE_CHILD)))

--- a/module/os/linux/zfs/zpl_xattr.c
+++ b/module/os/linux/zfs/zpl_xattr.c
@@ -1454,6 +1454,18 @@ zpl_permission(struct inode *ip, int mask)
 #endif
 	}
 
+#ifdef SB_NFSV4ACL
+	/*
+	 * By default trivial ACL (one that can be reduced to mode without
+	 * loss of information) grants ACE_WRITE_OWNER. If we have gotten to
+	 * this point, the kernel has already checked chown_ok() in the linux
+	 * vfs and *failed*. We want to keep normal posix behavior and so
+	 * return -EPERM here.
+	 */
+	if ((ITOZ(ip)->z_pflags & ZFS_ACL_TRIVIAL) && (mask & MAY_WRITE_OWNER))
+		return (-EPERM);
+#endif
+
 	for (i = 0; i < ARRAY_SIZE(mask2zfs); i++) {
 		if (mask & mask2zfs[i].kmask) {
 			to_check |= mask2zfs[i].zfsperm;


### PR DESCRIPTION
This commit fixes some incorrect handling of ACE_WRITE_OWNER and ACE_WRITE_ACL.

The internal representation of a trivial ACL in ZFS grants ACE_WRITE_OWNER to the file owner when the file owner has write (S_IWUSR) permissions. Although this is perhaps correct from a solaris perspective, and the permissions granted by ZFS match expectations based on RFC3530 (NFS4.0) and later revisions to the standars, this breaks expectations of linux kernel permitting the chown in the case of: root, CAP_FOWNER, or if it's a no-op.

This commit remediates the issue by the following:
1. in `zpl_permission()` we fail with -EPERM early if the ACL is trivial and chown requested. This avoids having to take any locks / do more complex checks). By the time we get here, the linux vfs already had chown_ok() return false.

2. in `zfs_zaccess_aces_check()` we do now allow owner, group, or everyone entries to grant ACE_WRITE_OWNER and ACE_WRITE_ACL permissions. This is a behavior change, but makes the access granted between trivial and non-trivial ACLs consistent.

3. in zpl_policy we remove a flawed check to allow chown in case user is the file owner.

4. when a non-trivial ACL is present we use the chown capability check rather than setdac because the latter allows override in case of the file owner.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
