### PR TITLE
NAS-139352 / 26.04 / Restrict cloning with different properties

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -440,8 +440,8 @@ get_usage(zfs_help_t idx)
 		return (gettext("\tredact <snapshot> <bookmark> "
 		    "<redaction_snapshot> ...\n"));
 	case HELP_REWRITE:
-		return (gettext("\trewrite [-Prvx] [-o <offset>] [-l <length>] "
-		    "<directory|file ...>\n"));
+		return (gettext("\trewrite [-CPSrvx] [-o <offset>] "
+		    "[-l <length>] <directory|file ...>\n"));
 	case HELP_JAIL:
 		return (gettext("\tjail <jailid|jailname> <filesystem>\n"));
 	case HELP_UNJAIL:
@@ -9211,10 +9211,16 @@ zfs_do_rewrite(int argc, char **argv)
 	zfs_rewrite_args_t args;
 	memset(&args, 0, sizeof (args));
 
-	while ((c = getopt(argc, argv, "Pl:o:rvx")) != -1) {
+	while ((c = getopt(argc, argv, "CPSl:o:rvx")) != -1) {
 		switch (c) {
+		case 'C':
+			args.flags |= ZFS_REWRITE_SKIP_BRT;
+			break;
 		case 'P':
 			args.flags |= ZFS_REWRITE_PHYSICAL;
+			break;
+		case 'S':
+			args.flags |= ZFS_REWRITE_SKIP_SNAPSHOT;
 			break;
 		case 'l':
 			args.len = strtoll(optarg, NULL, 0);

--- a/include/sys/dmu_objset.h
+++ b/include/sys/dmu_objset.h
@@ -236,6 +236,7 @@ int dmu_objset_find_dp(struct dsl_pool *dp, uint64_t ddobj,
     void *arg, int flags);
 void dmu_objset_evict_dbufs(objset_t *os);
 inode_timespec_t dmu_objset_snap_cmtime(objset_t *os);
+boolean_t dmu_objset_block_is_shared(objset_t *os, const blkptr_t *bp);
 
 /* called from dsl */
 void dmu_objset_sync(objset_t *os, zio_t *zio, dmu_tx_t *tx);

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -1633,7 +1633,9 @@ typedef struct zfs_rewrite_args {
 } zfs_rewrite_args_t;
 
 /* zfs_rewrite_args flags */
-#define	ZFS_REWRITE_PHYSICAL	0x1	/* Preserve logical birth time. */
+#define	ZFS_REWRITE_PHYSICAL		0x1 /* Preserve logical birth time. */
+#define	ZFS_REWRITE_SKIP_SNAPSHOT	0x2 /* Skip snapshot-shared blocks. */
+#define	ZFS_REWRITE_SKIP_BRT		0x4 /* Skip BRT-cloned blocks. */
 
 #define	ZFS_IOC_REWRITE		_IOW(0x83, 3, zfs_rewrite_args_t)
 

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -1438,6 +1438,10 @@ If this setting is 0, then even if feature@block_cloning is enabled,
 using functions and system calls that attempt to clone blocks will act as
 though the feature is disabled.
 .
+.It Sy zfs_bclone_strict_properties Ns = Ns Sy 1 Ns | Ns 0 Pq int
+Restricts block cloning between datasets with different properties
+(checksum, compression, copies, dedup, or special_small_blocks).
+.
 .It Sy zfs_bclone_wait_dirty Ns = Ns Sy 1 Ns | Ns 0 Pq int
 When set to 1 the FICLONE and FICLONERANGE ioctls will wait for any dirty
 data to be written to disk before proceeding.

--- a/man/man8/zfs-rewrite.8
+++ b/man/man8/zfs-rewrite.8
@@ -32,7 +32,7 @@
 .Sh SYNOPSIS
 .Nm zfs
 .Cm rewrite
-.Oo Fl Prvx Ns Oc
+.Oo Fl CPSrvx Ns Oc
 .Op Fl l Ar length
 .Op Fl o Ar offset
 .Ar file Ns | Ns Ar directory Ns …
@@ -45,6 +45,11 @@ as if they were atomically read and written back.
 .No See Sx NOTES .
 for more information about property changes that may be applied during rewrite.
 .Bl -tag -width "-r"
+.It Fl C
+Skip blocks that are shared via block cloning (BRT).
+Cloned blocks are referenced by multiple files or datasets.
+Rewriting these blocks would create separate copies and increase space usage.
+This flag prevents such expansion by skipping cloned blocks.
 .It Fl P
 Perform physical rewrite, preserving logical birth time of blocks.
 By default, rewrite updates logical birth times, making blocks appear
@@ -54,6 +59,12 @@ inclusion in incremental streams.
 Physical rewrite requires the
 .Sy physical_rewrite
 feature to be enabled on the pool.
+.It Fl S
+Skip blocks that are shared with snapshots.
+Blocks created before the most recent snapshot are shared with that snapshot.
+Rewriting these blocks would create new copies, leaving the old copies for
+the snapshot and increasing space usage.
+This flag prevents such expansion by skipping snapshot-shared blocks.
 .It Fl l Ar length
 Rewrite at most this number of bytes.
 .It Fl o Ar offset
@@ -82,6 +93,12 @@ will have no effect.
 .Pp
 Rewrite of cloned blocks and blocks that are part of any snapshots,
 same as some property changes may increase pool space usage.
+Use the
+.Fl C
+and
+.Fl S
+flags to skip cloned and snapshot-shared blocks respectively to prevent
+this expansion.
 Holes that were never written or were previously zero-compressed are
 not rewritten and will remain holes even if compression is disabled.
 .Pp

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -3046,6 +3046,24 @@ dmu_objset_willuse_space(objset_t *os, int64_t space, dmu_tx_t *tx)
 	dsl_pool_dirty_space(dmu_tx_pool(tx), space, tx);
 }
 
+/*
+ * Check if a block is shared with a snapshot in this objset.
+ * Returns B_TRUE if block was created before or at the time of the
+ * previous snapshot, B_FALSE otherwise.
+ */
+boolean_t
+dmu_objset_block_is_shared(objset_t *os, const blkptr_t *bp)
+{
+	if (BP_IS_HOLE(bp))
+		return (B_FALSE);
+
+	dsl_dataset_t *ds = os->os_dsl_dataset;
+	if (ds == NULL)
+		return (B_FALSE);
+
+	return (BP_GET_BIRTH(bp) <= dsl_dataset_phys(ds)->ds_prev_snap_txg);
+}
+
 #if defined(_KERNEL)
 EXPORT_SYMBOL(dmu_objset_zil);
 EXPORT_SYMBOL(dmu_objset_pool);
@@ -3090,4 +3108,5 @@ EXPORT_SYMBOL(dmu_objset_projectquota_enabled);
 EXPORT_SYMBOL(dmu_objset_projectquota_present);
 EXPORT_SYMBOL(dmu_objset_projectquota_upgradable);
 EXPORT_SYMBOL(dmu_objset_id_quota_upgrade);
+EXPORT_SYMBOL(dmu_objset_block_is_shared);
 #endif

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -309,7 +309,8 @@ tests = ['zfs_reservation_001_pos', 'zfs_reservation_002_pos']
 tags = ['functional', 'cli_root', 'zfs_reservation']
 
 [tests/functional/cli_root/zfs_rewrite]
-tests = ['zfs_rewrite', 'zfs_rewrite_physical']
+tests = ['zfs_rewrite', 'zfs_rewrite_physical', 'zfs_rewrite_skip_clone',
+    'zfs_rewrite_skip_snapshot']
 tags = ['functional', 'cli_root', 'zfs_rewrite']
 
 [tests/functional/cli_root/zfs_rollback]

--- a/tests/runfiles/sanity.run
+++ b/tests/runfiles/sanity.run
@@ -195,7 +195,8 @@ tests = ['zfs_reservation_001_pos', 'zfs_reservation_002_pos']
 tags = ['functional', 'cli_root', 'zfs_reservation']
 
 [tests/functional/cli_root/zfs_rewrite]
-tests = ['zfs_rewrite', 'zfs_rewrite_physical']
+tests = ['zfs_rewrite', 'zfs_rewrite_physical', 'zfs_rewrite_skip_clone',
+    'zfs_rewrite_skip_snapshot']
 tags = ['functional', 'cli_root', 'zfs_rewrite']
 
 [tests/functional/cli_root/zfs_rollback]

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -3943,4 +3943,26 @@ function pop_coredump_pattern
 	esac
 }
 
+#
+# get_same_blocks dataset1 path/to/file1 dataset2 path/to/file2 [key]
+#
+# Returns a space-separated list of the indexes (starting at 0) of the L0
+# blocks that are shared between both files (by first DVA and checksum).
+#
+function get_same_blocks # dataset1 file1 dataset2 file2 [key]
+{
+	typeset KEY=$5
+	if [ ${#KEY} -gt 0 ]; then
+		KEY="--key=$KEY"
+	fi
+	typeset zdbout1=$(mktemp)
+	typeset zdbout2=$(mktemp)
+	zdb $KEY -vvvvv $1 -O $2 | \
+	    awk '/ L0 / { print l++ " " $3 " " $7 }' > $zdbout1
+	zdb $KEY -vvvvv $3 -O $4 | \
+	    awk '/ L0 / { print l++ " " $3 " " $7 }' > $zdbout2
+	echo $(sort -n $zdbout1 $zdbout2 | uniq -d | cut -f1 -d' ')
+	rm -f $zdbout1 $zdbout2
+}
+
 . ${STF_SUITE}/include/kstat.shlib

--- a/tests/zfs-tests/include/tunables.cfg
+++ b/tests/zfs-tests/include/tunables.cfg
@@ -110,6 +110,7 @@ VOL_RECURSIVE			vol.recursive			UNSUPPORTED
 VOL_REQUEST_SYNC		vol.request_sync		zvol_request_sync
 VOL_USE_BLK_MQ			UNSUPPORTED			zvol_use_blk_mq
 BCLONE_ENABLED			bclone_enabled			zfs_bclone_enabled
+BCLONE_STRICT_PROPERTIES	bclone_strict_properties	zfs_bclone_strict_properties
 BCLONE_WAIT_DIRTY		bclone_wait_dirty		zfs_bclone_wait_dirty
 DIO_ENABLED			dio_enabled			zfs_dio_enabled
 DIO_STRICT			dio_strict			zfs_dio_strict

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -875,6 +875,8 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zfs_rewrite/setup.ksh \
 	functional/cli_root/zfs_rewrite/zfs_rewrite.ksh \
 	functional/cli_root/zfs_rewrite/zfs_rewrite_physical.ksh \
+	functional/cli_root/zfs_rewrite/zfs_rewrite_skip_clone.ksh \
+	functional/cli_root/zfs_rewrite/zfs_rewrite_skip_snapshot.ksh \
 	functional/cli_root/zfs_rollback/cleanup.ksh \
 	functional/cli_root/zfs_rollback/setup.ksh \
 	functional/cli_root/zfs_rollback/zfs_rollback_001_pos.ksh \

--- a/tests/zfs-tests/tests/functional/bclone/bclone_crossfs_corner_cases.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_crossfs_corner_cases.ksh
@@ -32,6 +32,15 @@ verify_runnable "both"
 
 verify_crossfs_block_cloning
 
+function cleanup
+{
+	log_must zfs inherit compress $TESTSRCFS
+	log_must zfs inherit compress $TESTDSTFS
+	log_must zfs inherit recordsize $TESTSRCFS
+	log_must zfs inherit recordsize $TESTDSTFS
+}
+log_onexit cleanup
+
 log_assert "Verify various corner cases in block cloning across datasets"
 
 # Disable compression to make sure we won't use embedded blocks.

--- a/tests/zfs-tests/tests/functional/bclone/bclone_crossfs_corner_cases_limited.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_crossfs_corner_cases_limited.ksh
@@ -32,6 +32,15 @@ verify_runnable "both"
 
 verify_crossfs_block_cloning
 
+function cleanup
+{
+	log_must zfs inherit compress $TESTSRCFS
+	log_must zfs inherit compress $TESTDSTFS
+	log_must zfs inherit recordsize $TESTSRCFS
+	log_must zfs inherit recordsize $TESTDSTFS
+}
+log_onexit cleanup
+
 log_assert "Verify various corner cases in block cloning across datasets"
 
 # Disable compression to make sure we won't use embedded blocks.

--- a/tests/zfs-tests/tests/functional/bclone/bclone_crossfs_data.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_crossfs_data.ksh
@@ -32,6 +32,13 @@ verify_runnable "both"
 
 verify_crossfs_block_cloning
 
+function cleanup
+{
+	log_must zfs inherit compress $TESTSRCFS
+	log_must zfs inherit compress $TESTDSTFS
+}
+log_onexit cleanup
+
 log_assert "Verify block cloning properly clones regular files across datasets"
 
 # Disable compression to make sure we won't use embedded blocks.

--- a/tests/zfs-tests/tests/functional/bclone/bclone_crossfs_embedded.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_crossfs_embedded.ksh
@@ -32,6 +32,13 @@ verify_runnable "both"
 
 verify_crossfs_block_cloning
 
+function cleanup
+{
+	log_must zfs inherit compress $TESTSRCFS
+	log_must zfs inherit compress $TESTDSTFS
+}
+log_onexit cleanup
+
 log_assert "Verify block cloning properly clones small files (with embedded blocks) across datasets"
 
 # Enable ZLE compression to make sure what is the maximum amount of data we

--- a/tests/zfs-tests/tests/functional/bclone/bclone_diffprops_all.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_diffprops_all.ksh
@@ -33,7 +33,26 @@ verify_runnable "both"
 
 verify_crossfs_block_cloning
 
+save_tunable BCLONE_STRICT_PROPERTIES
+
+function cleanup
+{
+	restore_tunable BCLONE_STRICT_PROPERTIES
+	log_must zfs inherit checksum $TESTSRCFS
+	log_must zfs inherit compress $TESTSRCFS
+	log_must zfs inherit copies $TESTSRCFS
+	log_must zfs inherit recordsize $TESTSRCFS
+	log_must zfs inherit checksum $TESTDSTFS
+	log_must zfs inherit compress $TESTDSTFS
+	log_must zfs inherit copies $TESTDSTFS
+	log_must zfs inherit recordsize $TESTDSTFS
+}
+log_onexit cleanup
+
 log_assert "Verify block cloning across datasets with different properties"
+
+# Disable strict property checking to allow cross-dataset cloning with different properties
+log_must set_tunable32 BCLONE_STRICT_PROPERTIES 0
 
 log_must zfs set checksum=off $TESTSRCFS
 log_must zfs set compress=off $TESTSRCFS
@@ -73,14 +92,5 @@ log_must zfs set recordsize=16384 $TESTDSTFS
 FILESIZE=$(random_int_between 2 32767)
 FILESIZE=$((FILESIZE * 64))
 bclone_test text $FILESIZE false $TESTSRCDIR $TESTDSTDIR
-
-log_must zfs inherit checksum $TESTSRCFS
-log_must zfs inherit compress $TESTSRCFS
-log_must zfs inherit copies $TESTSRCFS
-log_must zfs inherit recordsize $TESTSRCFS
-log_must zfs inherit checksum $TESTDSTFS
-log_must zfs inherit compress $TESTDSTFS
-log_must zfs inherit copies $TESTDSTFS
-log_must zfs inherit recordsize $TESTDSTFS
 
 log_pass

--- a/tests/zfs-tests/tests/functional/bclone/bclone_diffprops_checksum.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_diffprops_checksum.ksh
@@ -34,7 +34,22 @@ verify_runnable "both"
 
 verify_crossfs_block_cloning
 
+save_tunable BCLONE_STRICT_PROPERTIES
+
+function cleanup
+{
+	restore_tunable BCLONE_STRICT_PROPERTIES
+	log_must zfs inherit checksum $TESTSRCFS
+	log_must zfs inherit compress $TESTSRCFS
+	log_must zfs inherit checksum $TESTDSTFS
+	log_must zfs inherit compress $TESTDSTFS
+}
+log_onexit cleanup
+
 log_assert "Verify block cloning across datasets with different checksum properties"
+
+# Disable strict property checking to allow cross-dataset cloning with different properties
+log_must set_tunable32 BCLONE_STRICT_PROPERTIES 0
 
 log_must zfs set compress=off $TESTSRCFS
 log_must zfs set compress=off $TESTDSTFS
@@ -55,8 +70,5 @@ for srcprop in "${checksum_prop_vals[@]}"; do
         bclone_test random $FILESIZE false $TESTSRCDIR $TESTDSTDIR
     done
 done
-
-log_must zfs inherit checksum $TESTSRCFS
-log_must zfs inherit checksum $TESTDSTFS
 
 log_pass

--- a/tests/zfs-tests/tests/functional/bclone/bclone_diffprops_compress.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_diffprops_compress.ksh
@@ -34,7 +34,20 @@ verify_runnable "both"
 
 verify_crossfs_block_cloning
 
+save_tunable BCLONE_STRICT_PROPERTIES
+
+function cleanup
+{
+	restore_tunable BCLONE_STRICT_PROPERTIES
+	log_must zfs inherit compress $TESTSRCFS
+	log_must zfs inherit compress $TESTDSTFS
+}
+log_onexit cleanup
+
 log_assert "Verify block cloning across datasets with different compression properties"
+
+# Disable strict property checking to allow cross-dataset cloning with different properties
+log_must set_tunable32 BCLONE_STRICT_PROPERTIES 0
 
 for srcprop in "${compress_prop_vals[@]}"; do
     for dstprop in "${compress_prop_vals[@]}"; do
@@ -52,8 +65,5 @@ for srcprop in "${compress_prop_vals[@]}"; do
         bclone_test text $FILESIZE false $TESTSRCDIR $TESTDSTDIR
     done
 done
-
-log_must zfs inherit compress $TESTSRCFS
-log_must zfs inherit compress $TESTDSTFS
 
 log_pass

--- a/tests/zfs-tests/tests/functional/bclone/bclone_diffprops_copies.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_diffprops_copies.ksh
@@ -34,7 +34,22 @@ verify_runnable "both"
 
 verify_crossfs_block_cloning
 
+save_tunable BCLONE_STRICT_PROPERTIES
+
+function cleanup
+{
+	restore_tunable BCLONE_STRICT_PROPERTIES
+	log_must zfs inherit copies $TESTSRCFS
+	log_must zfs inherit compress $TESTSRCFS
+	log_must zfs inherit copies $TESTDSTFS
+	log_must zfs inherit compress $TESTDSTFS
+}
+log_onexit cleanup
+
 log_assert "Verify block cloning across datasets with different copies properties"
+
+# Disable strict property checking to allow cross-dataset cloning with different properties
+log_must set_tunable32 BCLONE_STRICT_PROPERTIES 0
 
 log_must zfs set compress=off $TESTSRCFS
 log_must zfs set compress=off $TESTDSTFS
@@ -52,8 +67,5 @@ for srcprop in "${copies_prop_vals[@]}"; do
         bclone_test random $FILESIZE false $TESTSRCDIR $TESTDSTDIR
     done
 done
-
-log_must zfs inherit copies $TESTSRCFS
-log_must zfs inherit copies $TESTDSTFS
 
 log_pass

--- a/tests/zfs-tests/tests/functional/bclone/bclone_diffprops_recordsize.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_diffprops_recordsize.ksh
@@ -34,7 +34,22 @@ verify_runnable "both"
 
 verify_crossfs_block_cloning
 
+save_tunable BCLONE_STRICT_PROPERTIES
+
+function cleanup
+{
+	restore_tunable BCLONE_STRICT_PROPERTIES
+	log_must zfs inherit recordsize $TESTSRCFS
+	log_must zfs inherit compress $TESTSRCFS
+	log_must zfs inherit recordsize $TESTDSTFS
+	log_must zfs inherit compress $TESTDSTFS
+}
+log_onexit cleanup
+
 log_assert "Verify block cloning across datasets with different recordsize properties"
+
+# Disable strict property checking to allow cross-dataset cloning with different properties
+log_must set_tunable32 BCLONE_STRICT_PROPERTIES 0
 
 log_must zfs set compress=off $TESTSRCFS
 log_must zfs set compress=off $TESTDSTFS
@@ -58,8 +73,5 @@ for srcprop in "${bclone_recsize_prop_vals[@]}"; do
         bclone_test random $FILESIZE false $TESTSRCDIR $TESTDSTDIR
     done
 done
-
-log_must zfs inherit recordsize $TESTSRCFS
-log_must zfs inherit recordsize $TESTDSTFS
 
 log_pass

--- a/tests/zfs-tests/tests/functional/bclone/bclone_prop_sync.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_prop_sync.ksh
@@ -34,6 +34,15 @@ verify_runnable "both"
 
 verify_crossfs_block_cloning
 
+function cleanup
+{
+	log_must zfs inherit compress $TESTSRCFS
+	log_must zfs inherit compress $TESTDSTFS
+	log_must zfs inherit sync $TESTSRCFS
+	log_must zfs inherit sync $TESTDSTFS
+}
+log_onexit cleanup
+
 log_assert "Verify block cloning with all sync property settings"
 
 log_must zfs set compress=zle $TESTSRCFS
@@ -63,8 +72,5 @@ for srcprop in "${sync_prop_vals[@]}"; do
         bclone_test random $FILESIZE false $TESTSRCDIR $TESTDSTDIR
     done
 done
-
-log_must zfs inherit sync $TESTSRCFS
-log_must zfs inherit sync $TESTDSTFS
 
 log_pass

--- a/tests/zfs-tests/tests/functional/bclone/bclone_samefs_corner_cases.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_samefs_corner_cases.ksh
@@ -30,6 +30,13 @@
 
 verify_runnable "both"
 
+function cleanup
+{
+	log_must zfs inherit compress $TESTSRCFS
+	log_must zfs inherit recordsize $TESTSRCFS
+}
+log_onexit cleanup
+
 log_assert "Verify various corner cases in block cloning within the same dataset"
 
 # Disable compression to make sure we won't use embedded blocks.

--- a/tests/zfs-tests/tests/functional/bclone/bclone_samefs_corner_cases_limited.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_samefs_corner_cases_limited.ksh
@@ -30,6 +30,13 @@
 
 verify_runnable "both"
 
+function cleanup
+{
+	log_must zfs inherit compress $TESTSRCFS
+	log_must zfs inherit recordsize $TESTSRCFS
+}
+log_onexit cleanup
+
 log_assert "Verify various corner cases in block cloning within the same dataset"
 
 # Disable compression to make sure we won't use embedded blocks.

--- a/tests/zfs-tests/tests/functional/bclone/bclone_samefs_data.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_samefs_data.ksh
@@ -30,6 +30,12 @@
 
 verify_runnable "both"
 
+function cleanup
+{
+	log_must zfs inherit compress $TESTSRCFS
+}
+log_onexit cleanup
+
 log_assert "Verify block cloning properly clones regular files within the same dataset"
 
 # Disable compression to make sure we won't use embedded blocks.

--- a/tests/zfs-tests/tests/functional/bclone/bclone_samefs_embedded.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_samefs_embedded.ksh
@@ -30,6 +30,12 @@
 
 verify_runnable "both"
 
+function cleanup
+{
+	log_must zfs inherit compress $TESTSRCFS
+}
+log_onexit cleanup
+
 log_assert "Verify block cloning properly clones small files (with embedded blocks) within the same dataset"
 
 # Enable ZLE compression to make sure what is the maximum amount of data we

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning.kshlib
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning.kshlib
@@ -35,27 +35,3 @@ function have_same_content
 	log_must [ "$hash1" = "$hash2" ]
 }
 
-#
-# get_same_blocks dataset1 path/to/file1 dataset2 path/to/file2
-#
-# Returns a space-separated list of the indexes (starting at 0) of the L0
-# blocks that are shared between both files (by first DVA and checksum).
-# Assumes that the two files have the same content, use have_same_content to
-# confirm that.
-#
-function get_same_blocks
-{
-    KEY=$5
-    if [ ${#KEY} -gt 0 ]; then
-        KEY="--key=$KEY"
-    fi
-	typeset zdbout1=$(mktemp)
-	typeset zdbout2=$(mktemp)
-	zdb $KEY -vvvvv $1 -O $2 | \
-	    awk '/ L0 / { print l++ " " $3 " " $7 }' > $zdbout1
-	zdb $KEY -vvvvv $3 -O $4 | \
-	    awk '/ L0 / { print l++ " " $3 " " $7 }' > $zdbout2
-	echo $(sort -n $zdbout1 $zdbout2 | uniq -d | cut -f1 -d' ')
-	rm -f $zdbout1 $zdbout2
-}
-

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rewrite/zfs_rewrite_skip_clone.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rewrite/zfs_rewrite_skip_clone.ksh
@@ -1,0 +1,83 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2026, iXsystems, Inc.
+#
+
+# DESCRIPTION:
+#	Verify zfs rewrite -C flag skips BRT-cloned blocks.
+#
+# STRATEGY:
+#	1. Create a test file and sync it.
+#	2. Clone the file using block cloning to share blocks via BRT.
+#	3. Rewrite clone with -C flag and verify blocks are NOT rewritten.
+#	4. Rewrite clone without -C flag and verify blocks ARE rewritten.
+
+. $STF_SUITE/include/libtest.shlib
+
+verify_runnable "global"
+
+function cleanup
+{
+	rm -rf $TESTDIR/*
+}
+
+log_assert "zfs rewrite -C flag skips BRT-cloned blocks"
+
+log_onexit cleanup
+
+log_must zfs set recordsize=128k $TESTPOOL/$TESTFS
+
+# Create source file (4 x 128KB = 4 blocks)
+log_must dd if=/dev/urandom of=$TESTDIR/source bs=128k count=4
+log_must sync_pool $TESTPOOL
+
+# Clone the file using block cloning
+log_must clonefile -f $TESTDIR/source $TESTDIR/clone
+log_must sync_pool $TESTPOOL
+
+# Verify blocks are actually shared initially
+typeset blocks=$(get_same_blocks $TESTPOOL/$TESTFS source \
+    $TESTPOOL/$TESTFS clone)
+log_must [ "$blocks" = "0 1 2 3" ]
+
+# Test 1: Rewrite clone WITH -C flag (should skip all cloned blocks)
+log_must zfs rewrite -C $TESTDIR/clone
+log_must sync_pool $TESTPOOL
+
+# Blocks should still be shared (all blocks were skipped)
+typeset blocks=$(get_same_blocks $TESTPOOL/$TESTFS source \
+    $TESTPOOL/$TESTFS clone)
+log_must [ "$blocks" = "0 1 2 3" ]
+
+# Test 2: Rewrite clone WITHOUT -C flag (should rewrite all blocks)
+log_must zfs rewrite $TESTDIR/clone
+log_must sync_pool $TESTPOOL
+
+# No blocks should be shared (clone has new blocks)
+typeset blocks=$(get_same_blocks $TESTPOOL/$TESTFS source \
+    $TESTPOOL/$TESTFS clone)
+log_must [ -z "$blocks" ]
+
+log_pass

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rewrite/zfs_rewrite_skip_snapshot.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rewrite/zfs_rewrite_skip_snapshot.ksh
@@ -1,0 +1,74 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2026, iXsystems, Inc.
+#
+
+# DESCRIPTION:
+#	Verify zfs rewrite -S flag skips snapshot-shared blocks.
+#
+# STRATEGY:
+#	1. Create a test file and sync it.
+#	2. Take a snapshot to share the blocks.
+#	3. Rewrite with -S flag and verify blocks are NOT rewritten.
+#	4. Rewrite without -S flag and verify blocks ARE rewritten.
+
+. $STF_SUITE/include/libtest.shlib
+
+function cleanup
+{
+	rm -rf $TESTDIR/*
+	zfs destroy -R $TESTPOOL/$TESTFS@snap1 2>/dev/null || true
+}
+
+log_assert "zfs rewrite -S flag skips snapshot-shared blocks"
+
+log_onexit cleanup
+
+log_must zfs set recordsize=128k $TESTPOOL/$TESTFS
+
+# Create test file (4 x 128KB = 4 blocks) and snapshot
+log_must dd if=/dev/urandom of=$TESTDIR/testfile bs=128k count=4
+log_must sync_pool $TESTPOOL
+log_must zfs snapshot $TESTPOOL/$TESTFS@snap1
+
+# Test 1: Rewrite WITH -S flag (should skip all snapshot-shared blocks)
+log_must zfs rewrite -S $TESTDIR/testfile
+log_must sync_pool $TESTPOOL
+
+# All blocks should still be shared (all blocks were skipped)
+typeset blocks=$(get_same_blocks $TESTPOOL/$TESTFS testfile \
+    $TESTPOOL/$TESTFS@snap1 testfile)
+log_must [ "$blocks" = "0 1 2 3" ]
+
+# Test 2: Rewrite WITHOUT -S flag (should rewrite all blocks)
+log_must zfs rewrite $TESTDIR/testfile
+log_must sync_pool $TESTPOOL
+
+# No blocks should be shared (all blocks were rewritten)
+typeset blocks=$(get_same_blocks $TESTPOOL/$TESTFS testfile \
+    $TESTPOOL/$TESTFS@snap1 testfile)
+log_must [ -z "$blocks" ]
+
+log_pass


### PR DESCRIPTION
Merge couple of upstream PRs, useful for tiering.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
