### PR TITLE
NAS-139817 / 26.04 / L2ARC: Add depth cap and write budget fairness for persistent markers

### DIFF
--- a/include/sys/arc_impl.h
+++ b/include/sys/arc_impl.h
@@ -56,10 +56,12 @@ typedef struct l2arc_info {
 	uint64_t	l2arc_total_capacity;	/* total L2ARC capacity */
 	uint64_t	l2arc_smallest_capacity; /* smallest device capacity */
 	/*
-	 * Per-device thread coordination for sublist processing
+	 * Per-device thread coordination for sublist processing.
+	 * reset: flags sublist marker for lazy reset to tail.
 	 */
 	boolean_t	*l2arc_sublist_busy[L2ARC_FEED_TYPES];
-	kmutex_t	l2arc_sublist_lock;	/* protects busy flags */
+	boolean_t	*l2arc_sublist_reset[L2ARC_FEED_TYPES];
+	kmutex_t	l2arc_sublist_lock;	/* protects busy/reset flags */
 	int		l2arc_next_sublist[L2ARC_FEED_TYPES]; /* round-robin */
 } l2arc_info_t;
 

--- a/include/sys/arc_impl.h
+++ b/include/sys/arc_impl.h
@@ -46,6 +46,10 @@ extern "C" {
  * and each of the states has two types: data and metadata.
  */
 #define	L2ARC_FEED_TYPES	4
+#define	L2ARC_MFU_META		0
+#define	L2ARC_MRU_META		1
+#define	L2ARC_MFU_DATA		2
+#define	L2ARC_MRU_DATA		3
 
 /*
  * L2ARC state and statistics for persistent marker management.
@@ -62,6 +66,12 @@ typedef struct l2arc_info {
 	boolean_t	*l2arc_sublist_busy[L2ARC_FEED_TYPES];
 	boolean_t	*l2arc_sublist_reset[L2ARC_FEED_TYPES];
 	kmutex_t	l2arc_sublist_lock;	/* protects busy/reset flags */
+	/*
+	 * Cumulative bytes scanned per pass since marker reset.
+	 * Limits how far persistent markers advance from tail
+	 * before resetting, based on % of state size.
+	 */
+	uint64_t	l2arc_ext_scanned[L2ARC_FEED_TYPES];
 	int		l2arc_next_sublist[L2ARC_FEED_TYPES]; /* round-robin */
 } l2arc_info_t;
 

--- a/include/sys/arc_impl.h
+++ b/include/sys/arc_impl.h
@@ -469,6 +469,12 @@ typedef struct l2arc_dev {
 	boolean_t		l2ad_thread_exit;	/* signal thread exit */
 	kmutex_t		l2ad_feed_thr_lock;	/* thread sleep/wake */
 	kcondvar_t		l2ad_feed_cv;		/* thread wakeup cv */
+	/*
+	 * Consecutive cycles where metadata filled write budget
+	 * while data passes got nothing written. Used to detect
+	 * monopolization and skip metadata to give data a chance.
+	 */
+	uint64_t		l2ad_meta_cycles;
 } l2arc_dev_t;
 
 /*

--- a/include/sys/arc_impl.h
+++ b/include/sys/arc_impl.h
@@ -60,6 +60,7 @@ typedef struct l2arc_info {
 	 */
 	boolean_t	*l2arc_sublist_busy[L2ARC_FEED_TYPES];
 	kmutex_t	l2arc_sublist_lock;	/* protects busy flags */
+	int		l2arc_next_sublist[L2ARC_FEED_TYPES]; /* round-robin */
 } l2arc_info_t;
 
 /*

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -233,6 +233,13 @@ resetting its markers to the tail.
 Lower values keep the marker closer to the tail under active workloads.
 Set to 0 to disable the depth cap.
 .
+.It Sy l2arc_meta_cycles Ns = Ns Sy 2 Pq u64
+How many consecutive cycles metadata may monopolize the write budget
+before being skipped to let data run.
+The default of 2 gives metadata roughly 67% and data 33% of L2ARC
+write bandwidth under sustained load.
+Higher values favor metadata; set to 0 to disable.
+.
 .It Sy l2arc_write_max Ns = Ns Sy 33554432 Ns B Po 32 MiB Pc Pq u64
 Maximum write rate in bytes per second for each L2ARC device.
 Used directly during initial fill, when DWPD limiting is disabled,

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -108,12 +108,14 @@ and only applicable in related situations.
 Seconds between L2ARC writing.
 .
 .It Sy l2arc_headroom Ns = Ns Sy 8 Pq u64
-How far through the ARC lists to search for L2ARC cacheable content,
+How far through the ARC lists to search for L2ARC cacheable content per cycle,
 expressed as a multiplier of the effective write size.
-ARC persistence across reboots can be achieved with persistent L2ARC
-by setting this parameter to
-.Sy 0 ,
-allowing the full length of ARC lists to be searched for cacheable content.
+Setting to
+.Sy 0
+disables the per-cycle headroom limit.
+Scan depth is also bounded by
+.Sy l2arc_ext_headroom_pct
+when persistent markers are active.
 .
 .It Sy l2arc_headroom_boost Ns = Ns Sy 200 Ns % Pq u64
 Scales

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -227,6 +227,12 @@ to enable caching/reading prefetches to/from L2ARC.
 .It Sy l2arc_norw Ns = Ns Sy 0 Ns | Ns 1 Pq int
 No reads during writes.
 .
+.It Sy l2arc_ext_headroom_pct Ns = Ns Sy 25 Pq u64
+Percentage of each ARC state's size that a pass may scan before
+resetting its markers to the tail.
+Lower values keep the marker closer to the tail under active workloads.
+Set to 0 to disable the depth cap.
+.
 .It Sy l2arc_write_max Ns = Ns Sy 33554432 Ns B Po 32 MiB Pc Pq u64
 Maximum write rate in bytes per second for each L2ARC device.
 Used directly during initial fill, when DWPD limiting is disabled,

--- a/man/man7/zpoolconcepts.7
+++ b/man/man7/zpoolconcepts.7
@@ -430,19 +430,15 @@ is updated even if no metadata structures are written.
 L2ARC operates in one of two modes depending on total cache capacity.
 When total L2ARC capacity is less than twice
 .Sy arc_c_max ,
-L2ARC uses exclusive caching,
-writing buffers to cache as they are evicted from ARC.
+L2ARC writes buffers to cache as they are evicted from ARC.
 When total capacity is at least twice
 .Sy arc_c_max ,
-L2ARC switches to inclusive caching with persistent markers
-that track scan positions,
-attempting to duplicate ARC contents as much as write throughput allows.
-Setting
-.Sy l2arc_headroom Ns = Ns Sy 0
-will result in scanning the full-length ARC lists for cacheable content to be
-written in L2ARC (persistent ARC).
-In inclusive mode, markers progress toward the head across iterations,
-naturally covering the full list.
+L2ARC uses persistent markers that track scan positions across iterations,
+writing cacheable content as write throughput allows.
+A depth cap
+.Pq Sy l2arc_ext_headroom_pct
+limits how far markers advance from the tail, keeping them focused on
+buffers soon to be evicted where caching adds the most value.
 .Pp
 If a cache device is added with
 .Nm zpool Cm add ,

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -9960,20 +9960,20 @@ l2arc_write_buffers(spa_t *spa, l2arc_dev_t *dev, uint64_t target_sz)
 		multilist_t *ml = l2arc_get_list(pass);
 		ASSERT3P(ml, !=, NULL);
 		int num_sublists = multilist_get_num_sublists(ml);
-		int current_sublist = multilist_get_random_index(ml);
 		uint64_t consumed_headroom = 0;
 
+		/*
+		 * Equal per-sublist headroom prevents later
+		 * sublists from getting disproportionate shares
+		 * that would defeat the depth cap.
+		 */
+		uint64_t sublist_headroom = headroom / num_sublists;
+
+		int current_sublist = spa->spa_l2arc_info.
+		    l2arc_next_sublist[pass];
 		int processed_sublists = 0;
 		while (processed_sublists < num_sublists && !full) {
-			uint64_t sublist_headroom;
-
-			if (consumed_headroom >= headroom)
-				break;
-
-			sublist_headroom = (headroom - consumed_headroom) /
-			    (num_sublists - processed_sublists);
-
-			if (sublist_headroom == 0)
+			if (consumed_headroom + sublist_headroom > headroom)
 				break;
 
 			/*
@@ -10015,6 +10015,10 @@ l2arc_write_buffers(spa_t *spa, l2arc_dev_t *dev, uint64_t target_sz)
 			current_sublist = (current_sublist + 1) % num_sublists;
 			processed_sublists++;
 		}
+
+		spa->spa_l2arc_info.l2arc_next_sublist[pass] =
+		    (spa->spa_l2arc_info.l2arc_next_sublist[pass] + 1) %
+		    num_sublists;
 
 		if (full == B_TRUE)
 			break;

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -9073,6 +9073,8 @@ l2arc_pool_markers_init(spa_t *spa)
 		    arc_state_alloc_markers(num_sublists);
 		spa->spa_l2arc_info.l2arc_sublist_busy[pass] =
 		    kmem_zalloc(num_sublists * sizeof (boolean_t), KM_SLEEP);
+		spa->spa_l2arc_info.l2arc_sublist_reset[pass] =
+		    kmem_zalloc(num_sublists * sizeof (boolean_t), KM_SLEEP);
 
 		for (int i = 0; i < num_sublists; i++) {
 			multilist_sublist_t *mls =
@@ -9117,12 +9119,18 @@ l2arc_pool_markers_fini(spa_t *spa)
 		    num_sublists);
 		spa->spa_l2arc_info.l2arc_markers[pass] = NULL;
 
-		/* Free sublist busy flags for this pass */
+		/* Free sublist busy and reset flags for this pass */
 		ASSERT3P(spa->spa_l2arc_info.l2arc_sublist_busy[pass], !=,
 		    NULL);
 		kmem_free(spa->spa_l2arc_info.l2arc_sublist_busy[pass],
 		    num_sublists * sizeof (boolean_t));
 		spa->spa_l2arc_info.l2arc_sublist_busy[pass] = NULL;
+
+		ASSERT3P(spa->spa_l2arc_info.l2arc_sublist_reset[pass], !=,
+		    NULL);
+		kmem_free(spa->spa_l2arc_info.l2arc_sublist_reset[pass],
+		    num_sublists * sizeof (boolean_t));
+		spa->spa_l2arc_info.l2arc_sublist_reset[pass] = NULL;
 	}
 
 	mutex_destroy(&spa->spa_l2arc_info.l2arc_sublist_lock);
@@ -9608,6 +9616,19 @@ l2arc_write_sublist(spa_t *spa, l2arc_dev_t *dev, int pass, int sublist_idx,
 	persistent_marker = spa->spa_l2arc_info.
 	    l2arc_markers[pass][sublist_idx];
 
+	/*
+	 * Check if this sublist's marker was flagged for reset to tail.
+	 * This handles depth cap resets and global resets without needing
+	 * to coordinate with actively-scanning threads.
+	 */
+	if (save_position &&
+	    spa->spa_l2arc_info.l2arc_sublist_reset[pass][sublist_idx]) {
+		multilist_sublist_remove(mls, persistent_marker);
+		multilist_sublist_insert_tail(mls, persistent_marker);
+		spa->spa_l2arc_info.l2arc_sublist_reset[pass][sublist_idx] =
+		    B_FALSE;
+	}
+
 	if (save_position && persistent_marker == multilist_sublist_head(mls)) {
 		multilist_sublist_unlock(mls);
 		return (B_FALSE);
@@ -9798,14 +9819,24 @@ next:
 	}
 
 	/*
-	 * Position persistent marker for next iteration. In case of
-	 * save_position, validate that prev_hdr still belongs to the current
-	 * sublist. The sublist lock is dropped during L2ARC write I/O, allowing
-	 * ARC eviction to potentially free prev_hdr. If freed, we can't do much
-	 * except to reset the marker.
+	 * Position persistent marker for next iteration.
+	 *
+	 * If a reset was flagged during our scan (sublist lock was dropped
+	 * for I/O, allowing another thread to set the flag), honor it by
+	 * moving the marker to tail instead of advancing.
+	 *
+	 * Otherwise, validate that prev_hdr still belongs to the current
+	 * sublist.  The sublist lock is dropped during L2ARC write I/O,
+	 * allowing ARC eviction to potentially free prev_hdr.  If freed,
+	 * we can't do much except to reset the marker.
 	 */
 	multilist_sublist_remove(mls, persistent_marker);
 	if (save_position &&
+	    spa->spa_l2arc_info.l2arc_sublist_reset[pass][sublist_idx]) {
+		multilist_sublist_insert_tail(mls, persistent_marker);
+		spa->spa_l2arc_info.l2arc_sublist_reset[pass][sublist_idx] =
+		    B_FALSE;
+	} else if (save_position &&
 	    multilist_link_active(&prev_hdr->b_l1hdr.b_arc_node)) {
 		if (hdr != NULL) {
 			/*
@@ -9845,40 +9876,33 @@ l2arc_blk_fetch_done(zio_t *zio)
 }
 
 /*
- * Reset all L2ARC markers to tail position for the given spa.
+ * Flag all sublists for a single pass for lazy marker reset to tail.
+ * Each sublist's marker will be reset when next visited by a feed thread.
+ */
+static void
+l2arc_flag_pass_reset(spa_t *spa, int pass)
+{
+	ASSERT(MUTEX_HELD(&spa->spa_l2arc_info.l2arc_sublist_lock));
+
+	multilist_t *ml = l2arc_get_list(pass);
+	int num_sublists = multilist_get_num_sublists(ml);
+
+	for (int i = 0; i < num_sublists; i++) {
+		multilist_sublist_t *mls = multilist_sublist_lock_idx(ml, i);
+		spa->spa_l2arc_info.l2arc_sublist_reset[pass][i] = B_TRUE;
+		multilist_sublist_unlock(mls);
+	}
+}
+
+/*
+ * Flag all L2ARC markers for lazy reset to tail for the given spa.
+ * Each sublist's marker will be reset when next visited by a feed thread.
  */
 static void
 l2arc_reset_all_markers(spa_t *spa)
 {
-	ASSERT(spa->spa_l2arc_info.l2arc_markers != NULL);
-	ASSERT(MUTEX_HELD(&spa->spa_l2arc_info.l2arc_sublist_lock));
-
-	for (int pass = 0; pass < L2ARC_FEED_TYPES; pass++) {
-		if (spa->spa_l2arc_info.l2arc_markers[pass] == NULL)
-			continue;
-
-		multilist_t *ml = l2arc_get_list(pass);
-		int num_sublists = multilist_get_num_sublists(ml);
-
-		for (int i = 0; i < num_sublists; i++) {
-			ASSERT3P(spa->spa_l2arc_info.l2arc_markers[pass][i],
-			    !=, NULL);
-			multilist_sublist_t *mls =
-			    multilist_sublist_lock_idx(ml, i);
-
-			/* Remove from current position */
-			ASSERT(multilist_link_active(&spa->spa_l2arc_info.
-			    l2arc_markers[pass][i]->b_l1hdr.b_arc_node));
-			multilist_sublist_remove(mls, spa->spa_l2arc_info.
-			    l2arc_markers[pass][i]);
-
-			/* Insert at tail (like initialization) */
-			multilist_sublist_insert_tail(mls,
-			    spa->spa_l2arc_info.l2arc_markers[pass][i]);
-
-			multilist_sublist_unlock(mls);
-		}
-	}
+	for (int pass = 0; pass < L2ARC_FEED_TYPES; pass++)
+		l2arc_flag_pass_reset(spa, pass);
 
 	/* Reset write counter */
 	spa->spa_l2arc_info.l2arc_total_writes = 0;

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -9622,7 +9622,7 @@ l2arc_write_sublist(spa_t *spa, l2arc_dev_t *dev, int pass, int sublist_idx,
     uint64_t *consumed, uint64_t sublist_headroom, boolean_t save_position)
 {
 	multilist_sublist_t *mls;
-	arc_buf_hdr_t *hdr, *prev_hdr;
+	arc_buf_hdr_t *hdr;
 	arc_buf_hdr_t *persistent_marker, *local_marker;
 	boolean_t full = B_FALSE;
 	boolean_t scan_from_head = B_FALSE;
@@ -9669,12 +9669,9 @@ l2arc_write_sublist(spa_t *spa, l2arc_dev_t *dev, int pass, int sublist_idx,
 		ASSERT3P(hdr, !=, NULL);
 	}
 
-	prev_hdr = hdr;
-
 	while (hdr != NULL) {
 		kmutex_t *hash_lock;
 		abd_t *to_write = NULL;
-		prev_hdr = hdr;
 
 		hash_lock = HDR_LOCK(hdr);
 		if (!mutex_tryenter(hash_lock)) {
@@ -9836,42 +9833,25 @@ next:
 		multilist_sublist_remove(mls, local_marker);
 	}
 
-	/*
-	 * Position persistent marker for next iteration.
-	 *
-	 * If a reset was flagged during our scan (sublist lock was dropped
-	 * for I/O, allowing another thread to set the flag), honor it by
-	 * moving the marker to tail instead of advancing.
-	 *
-	 * Otherwise, validate that prev_hdr still belongs to the current
-	 * sublist.  The sublist lock is dropped during L2ARC write I/O,
-	 * allowing ARC eviction to potentially free prev_hdr.  If freed,
-	 * we can't do much except to reset the marker.
-	 */
+	/* Reposition persistent marker for next iteration. */
 	multilist_sublist_remove(mls, persistent_marker);
 	if (save_position &&
 	    spa->spa_l2arc_info.l2arc_sublist_reset[pass][sublist_idx]) {
+		/* Reset flagged during scan, restart from tail. */
 		multilist_sublist_insert_tail(mls, persistent_marker);
 		spa->spa_l2arc_info.l2arc_sublist_reset[pass][sublist_idx] =
 		    B_FALSE;
-	} else if (save_position &&
-	    multilist_link_active(&prev_hdr->b_l1hdr.b_arc_node)) {
-		if (hdr != NULL) {
-			/*
-			 * Break: prev_hdr not written, retry next time.
-			 * Scan is TAIL->HEAD, so insert_after = retry.
-			 */
-			multilist_sublist_insert_after(mls, prev_hdr,
-			    persistent_marker);
-		} else {
-			/*
-			 * List end: prev_hdr processed, move on.
-			 * insert_before = skip prev_hdr next scan.
-			 */
-			multilist_sublist_insert_before(mls, prev_hdr,
-			    persistent_marker);
-		}
+	} else if (save_position && hdr != NULL) {
+		/*
+		 * Write budget or sublist headroom exhausted, position
+		 * marker after hdr to retry it next time.
+		 */
+		multilist_sublist_insert_after(mls, hdr, persistent_marker);
+	} else if (save_position) {
+		/* End of sublist, position marker at head. */
+		multilist_sublist_insert_head(mls, persistent_marker);
 	} else {
+		/* Non-persistent, reset marker to tail. */
 		multilist_sublist_insert_tail(mls, persistent_marker);
 	}
 
@@ -10051,7 +10031,7 @@ l2arc_write_buffers(spa_t *spa, l2arc_dev_t *dev, uint64_t target_sz)
 		    l2arc_next_sublist[pass];
 		int processed_sublists = 0;
 		while (processed_sublists < num_sublists && !full) {
-			if (consumed_headroom + sublist_headroom > headroom)
+			if (consumed_headroom >= headroom)
 				break;
 
 			/*

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -964,6 +964,15 @@ static int l2arc_mfuonly = 0;
 static uint64_t l2arc_ext_headroom_pct = 25;
 
 /*
+ * Metadata monopolization limit.  When metadata fills the write budget
+ * for this many consecutive cycles while data gets nothing, skip metadata
+ * for one cycle to let data run, then reset the counter.
+ * With N=2, the steady-state pattern under sustained monopolization is
+ * 2 metadata cycles followed by 1 data cycle (67%/33% split).
+ */
+static uint64_t l2arc_meta_cycles = 2;
+
+/*
  * L2ARC TRIM
  * l2arc_trim_ahead : A ZFS module parameter that controls how much ahead of
  * 		the current write size (l2arc_write_max) we should TRIM if we
@@ -9998,6 +10007,12 @@ l2arc_write_buffers(spa_t *spa, l2arc_dev_t *dev, uint64_t target_sz)
 	/*
 	 * Copy buffers for L2ARC writing.
 	 */
+	boolean_t skip_meta = (save_position &&
+	    l2arc_meta_cycles > 0 &&
+	    dev->l2ad_meta_cycles >= l2arc_meta_cycles);
+	if (skip_meta)
+		dev->l2ad_meta_cycles = 0;
+
 	for (int pass = 0; pass < L2ARC_FEED_TYPES; pass++) {
 		/*
 		 * pass == 0: MFU meta
@@ -10012,6 +10027,9 @@ l2arc_write_buffers(spa_t *spa, l2arc_dev_t *dev, uint64_t target_sz)
 			if (pass == 3)
 				continue;
 		}
+
+		if (skip_meta && pass <= L2ARC_MRU_META)
+			continue;
 
 		headroom = target_sz * l2arc_headroom;
 		if (zfs_compressed_arc_enabled)
@@ -10081,6 +10099,14 @@ l2arc_write_buffers(spa_t *spa, l2arc_dev_t *dev, uint64_t target_sz)
 		    num_sublists;
 
 		/*
+		 * Count consecutive metadata monopolization toward
+		 * l2arc_meta_cycles.  Only count when metadata actually
+		 * filled the write budget, starving data passes.
+		 */
+		if (save_position && pass <= L2ARC_MRU_META && full)
+			dev->l2ad_meta_cycles++;
+
+		/*
 		 * Depth cap: track cumulative bytes scanned per pass
 		 * and reset markers when the scan cap is reached.
 		 * Keeps the marker near the tail where L2ARC adds
@@ -10108,6 +10134,13 @@ l2arc_write_buffers(spa_t *spa, l2arc_dev_t *dev, uint64_t target_sz)
 		if (full == B_TRUE)
 			break;
 	}
+
+	/*
+	 * If nothing was written at all, reset monopolization counter.
+	 * No point skipping metadata if data has nothing either.
+	 */
+	if (write_asize == 0)
+		dev->l2ad_meta_cycles = 0;
 
 	/* No buffers selected for writing? */
 	if (pio == NULL) {
@@ -11751,6 +11784,9 @@ ZFS_MODULE_PARAM(zfs_l2arc, l2arc_, mfuonly, INT, ZMOD_RW,
 
 ZFS_MODULE_PARAM(zfs_l2arc, l2arc_, exclude_special, INT, ZMOD_RW,
 	"Exclude dbufs on special vdevs from being cached to L2ARC if set.");
+
+ZFS_MODULE_PARAM(zfs_l2arc, l2arc_, meta_cycles, U64, ZMOD_RW,
+	"Consecutive metadata cycles before skipping to let data run");
 
 ZFS_MODULE_PARAM(zfs_l2arc, l2arc_, ext_headroom_pct, U64, ZMOD_RW,
 	"Depth cap as percentage of state size for marker reset");

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -957,6 +957,13 @@ int l2arc_exclude_special = 0;
 static int l2arc_mfuonly = 0;
 
 /*
+ * Depth cap as percentage of state size.  Each pass resets its markers
+ * to tail after scanning this fraction of the state.  Keeps markers
+ * focused on the tail zone where L2ARC adds the most value.
+ */
+static uint64_t l2arc_ext_headroom_pct = 25;
+
+/*
  * L2ARC TRIM
  * l2arc_trim_ahead : A ZFS module parameter that controls how much ahead of
  * 		the current write size (l2arc_write_max) we should TRIM if we
@@ -9083,6 +9090,8 @@ l2arc_pool_markers_init(spa_t *spa)
 			    spa->spa_l2arc_info.l2arc_markers[pass][i]);
 			multilist_sublist_unlock(mls);
 		}
+
+		spa->spa_l2arc_info.l2arc_ext_scanned[pass] = 0;
 	}
 }
 
@@ -9876,6 +9885,31 @@ l2arc_blk_fetch_done(zio_t *zio)
 }
 
 /*
+ * Return the total size of the ARC state corresponding to the given
+ * L2ARC pass number (0..3).
+ */
+static uint64_t
+l2arc_get_state_size(int pass)
+{
+	switch (pass) {
+	case L2ARC_MFU_META:
+		return (zfs_refcount_count(
+		    &arc_mfu->arcs_size[ARC_BUFC_METADATA]));
+	case L2ARC_MRU_META:
+		return (zfs_refcount_count(
+		    &arc_mru->arcs_size[ARC_BUFC_METADATA]));
+	case L2ARC_MFU_DATA:
+		return (zfs_refcount_count(
+		    &arc_mfu->arcs_size[ARC_BUFC_DATA]));
+	case L2ARC_MRU_DATA:
+		return (zfs_refcount_count(
+		    &arc_mru->arcs_size[ARC_BUFC_DATA]));
+	default:
+		return (0);
+	}
+}
+
+/*
  * Flag all sublists for a single pass for lazy marker reset to tail.
  * Each sublist's marker will be reset when next visited by a feed thread.
  */
@@ -9892,6 +9926,8 @@ l2arc_flag_pass_reset(spa_t *spa, int pass)
 		spa->spa_l2arc_info.l2arc_sublist_reset[pass][i] = B_TRUE;
 		multilist_sublist_unlock(mls);
 	}
+
+	spa->spa_l2arc_info.l2arc_ext_scanned[pass] = 0;
 }
 
 /*
@@ -10043,6 +10079,31 @@ l2arc_write_buffers(spa_t *spa, l2arc_dev_t *dev, uint64_t target_sz)
 		spa->spa_l2arc_info.l2arc_next_sublist[pass] =
 		    (spa->spa_l2arc_info.l2arc_next_sublist[pass] + 1) %
 		    num_sublists;
+
+		/*
+		 * Depth cap: track cumulative bytes scanned per pass
+		 * and reset markers when the scan cap is reached.
+		 * Keeps the marker near the tail where L2ARC adds
+		 * the most value.
+		 */
+		if (save_position) {
+			mutex_enter(&spa->spa_l2arc_info.l2arc_sublist_lock);
+
+			spa->spa_l2arc_info.l2arc_ext_scanned[pass] +=
+			    consumed_headroom;
+
+			uint64_t state_sz = l2arc_get_state_size(pass);
+			uint64_t scan_cap =
+			    state_sz * l2arc_ext_headroom_pct / 100;
+
+			if (scan_cap > 0 &&
+			    spa->spa_l2arc_info.l2arc_ext_scanned[pass] >=
+			    scan_cap) {
+				l2arc_flag_pass_reset(spa, pass);
+			}
+
+			mutex_exit(&spa->spa_l2arc_info.l2arc_sublist_lock);
+		}
 
 		if (full == B_TRUE)
 			break;
@@ -11690,6 +11751,9 @@ ZFS_MODULE_PARAM(zfs_l2arc, l2arc_, mfuonly, INT, ZMOD_RW,
 
 ZFS_MODULE_PARAM(zfs_l2arc, l2arc_, exclude_special, INT, ZMOD_RW,
 	"Exclude dbufs on special vdevs from being cached to L2ARC if set.");
+
+ZFS_MODULE_PARAM(zfs_l2arc, l2arc_, ext_headroom_pct, U64, ZMOD_RW,
+	"Depth cap as percentage of state size for marker reset");
 
 ZFS_MODULE_PARAM_CALL(zfs_arc, zfs_arc_, lotsfree_percent, param_set_arc_int,
 	param_get_uint, ZMOD_RW, "System free memory I/O throttle in bytes");

--- a/tests/zfs-tests/include/tunables.cfg
+++ b/tests/zfs-tests/include/tunables.cfg
@@ -53,6 +53,7 @@ L2ARC_NOPREFETCH		l2arc.noprefetch		l2arc_noprefetch
 L2ARC_REBUILD_BLOCKS_MIN_L2SIZE	l2arc.rebuild_blocks_min_l2size	l2arc_rebuild_blocks_min_l2size
 L2ARC_REBUILD_ENABLED		l2arc.rebuild_enabled		l2arc_rebuild_enabled
 L2ARC_TRIM_AHEAD		l2arc.trim_ahead		l2arc_trim_ahead
+L2ARC_META_CYCLES		l2arc.meta_cycles		l2arc_meta_cycles
 L2ARC_WRITE_MAX			l2arc.write_max			l2arc_write_max
 LIVELIST_CONDENSE_NEW_ALLOC	livelist.condense.new_alloc	zfs_livelist_condense_new_alloc
 LIVELIST_CONDENSE_SYNC_CANCEL	livelist.condense.sync_cancel	zfs_livelist_condense_sync_cancel

--- a/tests/zfs-tests/include/tunables.cfg
+++ b/tests/zfs-tests/include/tunables.cfg
@@ -47,6 +47,7 @@ INITIALIZE_VALUE		initialize_value		zfs_initialize_value
 KEEP_LOG_SPACEMAPS_AT_EXPORT	keep_log_spacemaps_at_export	zfs_keep_log_spacemaps_at_export
 LUA_MAX_MEMLIMIT		lua.max_memlimit		zfs_lua_max_memlimit
 L2ARC_DWPD_LIMIT		l2arc.dwpd_limit		l2arc_dwpd_limit
+L2ARC_EXT_HEADROOM_PCT		l2arc.ext_headroom_pct		l2arc_ext_headroom_pct
 L2ARC_MFUONLY			l2arc.mfuonly			l2arc_mfuonly
 L2ARC_NOPREFETCH		l2arc.noprefetch		l2arc_noprefetch
 L2ARC_REBUILD_BLOCKS_MIN_L2SIZE	l2arc.rebuild_blocks_min_l2size	l2arc_rebuild_blocks_min_l2size


### PR DESCRIPTION
### Motivation and Context
Follow-up to #18093. With persistent markers, scan positions drift indefinitely toward the head of ARC eviction lists where buffers will stay in ARC for a while, writing them to L2ARC adds little value since ARC already serves them. The tail is where buffers are closest to eviction and benefit most from L2ARC. Additionally, when eviction outpaces L2ARC write throughput, metadata passes run first and can fill the entire write budget every cycle, starving data passes of buffers that could have produced L2ARC hits.
Upstream PR: https://github.com/openzfs/zfs/pull/18289

### Description
- **Even sublist headroom distribution**: Divide headroom equally across sublists with round-robin visitation to prevent any single sublist from dominating the write budget.                                                                                         - **Lazy sublist reset flags**: Signal marker resets via per-sublist boolean flags instead of direct manipulation, consumed at scan start and end. Decouples reset signaling from active scans.
- **Scan-based depth cap**: Track cumulative bytes scanned per pass. Reset markers to tail when scanning exceeds `l2arc_ext_headroom_pct` (default 25%) of ARC state size. Keeps markers in the tail zone where L2ARC adds the most value. Set to 0 to disable.
- **Write budget fairness**: After l2arc_meta_cycles (default 2) consecutive cycles where metadata fills the budget, skip metadata for one cycle to let data run. Only triggers when data states have buffers to write. Set to 0 to disable.
- **Man page updates**: Remove stale "inclusive caching" terminology and document new tunables.

### How Has This Been Tested?
- CI Testing
- Manual unit tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
