### PR TITLE
NAS-140326 / 26.0.0-BETA.2 / zvol: include copy ops in ZVOL_OP_IS_SUPPORTED check (by ixhamza)

### DIFF
--- a/module/os/linux/zfs/zvol_os.c
+++ b/module/os/linux/zfs/zvol_os.c
@@ -482,7 +482,12 @@ zvol_read_task(void *arg)
 	op == REQ_OP_DISCARD)
 
 /* Is this IO type supported by zvols? */
+#ifdef HAVE_BLKDEV_COPY_OFFLOAD
+#define	ZVOL_OP_IS_SUPPORTED(op) \
+	(op == REQ_OP_READ || ZVOL_OP_IS_WRITE(op) || op_is_copy(op))
+#else
 #define	ZVOL_OP_IS_SUPPORTED(op) (op == REQ_OP_READ || ZVOL_OP_IS_WRITE(op))
+#endif
 
 /* Get the IO opcode */
 #define	ZVOL_OP(bio, rq) (bio != NULL ? bio_op(bio) : req_op(rq))


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->
<!--- Provide a general summary of your changes in the Title above -->
Upstream PR: https://github.com/openzfs/zfs/pull/18336

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
e09c86cb1f added an allowlist of supported BIO operations in ZVOL_OP_IS_SUPPORTED, but did not include REQ_OP_COPY_SRC and REQ_OP_COPY_DST. This causes block cloning between zvols via copy_file_range() to fail, as the copy BIOs are rejected before reaching the op_is_copy() handler that dispatches to zvol_clone_range_impl().

### Description
<!--- Describe your changes in detail -->
Fix by adding op_is_copy() to the supported ops check, gated behind HAVE_BLKDEV_COPY_OFFLOAD.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
```bash
VOLBLOCKSIZE=16K
truncate -s 4G /tmp/f1
zpool create tank /tmp/f1
zfs create -o volblocksize=$VOLBLOCKSIZE -V 1G tank/zv1
zfs create -o volblocksize=$VOLBLOCKSIZE -V 1G tank/zv2
dd if=/dev/urandom of=/dev/zd0 bs=$VOLBLOCKSIZE count=16
zpool sync tank

python3 -c "
import os
fd_in = os.open('/dev/zd0', os.O_RDONLY | os.O_DIRECT)
fd_out = os.open('/dev/zd16', os.O_WRONLY | os.O_DIRECT)
print(os.copy_file_range(fd_in, fd_out, 16 * 1024 * 16, 0, 0))
os.close(fd_in)
os.close(fd_out)
"
# Output: 262144

# Verify blocks are shared (same DVAs) between source and destination:
zdb -vvvvv tank/zv1 | awk '/ L0 / { print l++ " " $3 " " $7 }' > /tmp/src
zdb -vvvvv tank/zv2 | awk '/ L0 / { print l++ " " $3 " " $7 }' > /tmp/dst
sort -n /tmp/src /tmp/dst | uniq -d | cut -f1 -d' '
# Output: 1 through 16 (all data blocks shared)

Before the fix, copy_file_range() returned ENOTSUPP.
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).


Original PR: https://github.com/truenas/zfs/pull/369
