### PR TITLE
NAS-140372 / 26.04 / CI: Support repository variable override for ZTS OS selection

### DIFF
--- a/.github/workflows/scripts/generate-ci-type.py
+++ b/.github/workflows/scripts/generate-ci-type.py
@@ -3,13 +3,16 @@
 """
 Determine the CI type based on the change list and commit message.
 
-Prints "quick" if (explicity required by user):
+Output format: "<type> <source>" where source is "manual" (from
+ZFS-CI-Type commit tag) or "auto" (from file change heuristics).
+
+Prints "quick manual" if:
 - the *last* commit message contains 'ZFS-CI-Type: quick'
-or if (heuristics):
+or "quick auto" if (heuristics):
 - the files changed are not in the list of specified directories, and
 - all commit messages do not contain 'ZFS-CI-Type: (full|linux|freebsd)'
 
-Otherwise prints "full".
+Otherwise prints "full auto" (or "<type> manual" if explicitly requested).
 """
 
 import sys
@@ -58,9 +61,10 @@ if __name__ == '__main__':
 
     head, base = sys.argv[1:3]
 
-    def output_type(type, reason):
-        print(f'{prog}: will run {type} CI: {reason}', file=sys.stderr)
-        print(type)
+    def output_type(type, source, reason):
+        print(f'{prog}: will run {type} CI ({source}): {reason}',
+              file=sys.stderr)
+        print(f'{type} {source}')
         sys.exit(0)
 
     # check last (HEAD) commit message
@@ -70,7 +74,8 @@ if __name__ == '__main__':
 
     for line in last_commit_message_raw.stdout.decode().splitlines():
         if line.strip().lower() == 'zfs-ci-type: quick':
-            output_type('quick', f'requested by HEAD commit {head}')
+            output_type('quick', 'manual',
+                        f'requested by HEAD commit {head}')
 
     # check all commit messages
     all_commit_message_raw = subprocess.run([
@@ -84,11 +89,14 @@ if __name__ == '__main__':
         if line.startswith('ZFS-CI-Commit:'):
             commit_ref = line.lstrip('ZFS-CI-Commit:').rstrip()
         if line.strip().lower() == 'zfs-ci-type: freebsd':
-            output_type('freebsd', f'requested by commit {commit_ref}')
+            output_type('freebsd', 'manual',
+                        f'requested by commit {commit_ref}')
         if line.strip().lower() == 'zfs-ci-type: linux':
-            output_type('linux', f'requested by commit {commit_ref}')
+            output_type('linux', 'manual',
+                        f'requested by commit {commit_ref}')
         if line.strip().lower() == 'zfs-ci-type: full':
-            output_type('full', f'requested by commit {commit_ref}')
+            output_type('full', 'manual',
+                        f'requested by commit {commit_ref}')
 
     # check changed files
     changed_files_raw = subprocess.run([
@@ -104,9 +112,10 @@ if __name__ == '__main__':
             for r in FULL_RUN_REGEX:
                 if r.match(f):
                     output_type(
-                        'full',
+                        'full', 'auto',
                         f'changed file "{f}" matches pattern "{r.pattern}"'
                         )
 
     # catch-all
-    output_type('quick', 'no changed file matches full CI patterns')
+    output_type('quick', 'auto',
+                'no changed file matches full CI patterns')

--- a/.github/workflows/zfs-qemu.yml
+++ b/.github/workflows/zfs-qemu.yml
@@ -35,12 +35,13 @@ jobs:
         id: os
         run: |
           ci_type="default"
+          ci_source="auto"
 
           # determine CI type when running on PR
           if ${{ github.event_name == 'pull_request' }}; then
             head=${{ github.event.pull_request.head.sha }}
             base=${{ github.event.pull_request.base.sha }}
-            ci_type=$(python3 .github/workflows/scripts/generate-ci-type.py $head $base)
+            read ci_type ci_source <<< "$(python3 .github/workflows/scripts/generate-ci-type.py $head $base)"
           fi
 
           case "$ci_type" in
@@ -58,6 +59,19 @@ jobs:
             os_selection='["almalinux8", "almalinux9", "almalinux10", "centos-stream9", "centos-stream10", "debian12", "debian13", "fedora42", "fedora43", "freebsd14-3r", "freebsd15-0s", "freebsd16-0c", "ubuntu22", "ubuntu24"]'
             ;;
           esac
+
+          # Repository-level override for OS selection.
+          # Set vars.ZTS_OS_OVERRIDE in repo settings to restrict targets
+          # (e.g. '["debian13"]' or '["debian13", "fedora42"]').
+          # Manual ZFS-CI-Type in commit messages bypasses the override.
+          if [ -n "${{ vars.ZTS_OS_OVERRIDE }}" ] && [ "$ci_source" != "manual" ]; then
+            override='${{ vars.ZTS_OS_OVERRIDE }}'
+            if echo "$override" | jq -e 'type == "array"' >/dev/null 2>&1; then
+              os_selection="$override"
+            else
+              echo "::warning::Invalid ZTS_OS_OVERRIDE, using default"
+            fi
+          fi
 
           if ${{ github.event.inputs.fedora_kernel_ver != '' }}; then
               # They specified a custom kernel version for Fedora.


### PR DESCRIPTION
Allow restricting ZTS OS targets by setting the vars.ZTS_OS_OVERRIDE repository variable (e.g. '["debian13"]') to reduce shared runner contention when running the full OS matrix is unnecessary. When unset, the existing ci_type-based OS selection is used unchanged.

Reviewed-by: Brian Behlendorf <behlendorf1@llnl.gov>

Closes #18342

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
