### PR TITLE
NAS-140605 / 26.0.0-BETA.2 / Fix snapshot automount deadlock during concurrent zfs recv (by ixhamza)

### DIFF
--- a/module/os/linux/zfs/zfs_ctldir.c
+++ b/module/os/linux/zfs/zfs_ctldir.c
@@ -1366,8 +1366,7 @@ zfsctl_snapshot_mount(struct path *path, int flags)
 error:
 	kmem_free(full_name, ZFS_MAX_DATASET_NAME_LEN);
 	kmem_free(full_path, MAXPATHLEN);
-
-	zfs_exit(zfsvfs, FTAG);
+	kmem_free(options, 7);
 
 	return (error);
 }

--- a/module/os/linux/zfs/zfs_ctldir.c
+++ b/module/os/linux/zfs/zfs_ctldir.c
@@ -1201,8 +1201,10 @@ zfsctl_snapshot_mount(struct path *path, int flags)
 
 	error = zfsctl_snapshot_name(zfsvfs, dname(dentry),
 	    ZFS_MAX_DATASET_NAME_LEN, full_name);
-	if (error)
+	if (error) {
+		zfs_exit(zfsvfs, FTAG);
 		goto error;
+	}
 
 	if (is_current_chrooted() == 0) {
 		/*
@@ -1220,6 +1222,7 @@ zfsctl_snapshot_mount(struct path *path, int flags)
 		error = get_root_path(&mnt_path, m, MAXPATHLEN);
 		if (error != 0) {
 			kmem_free(m, MAXPATHLEN);
+			zfs_exit(zfsvfs, FTAG);
 			goto error;
 		}
 		mutex_enter(&zfsvfs->z_vfs->vfs_mntpt_lock);
@@ -1251,6 +1254,33 @@ zfsctl_snapshot_mount(struct path *path, int flags)
 
 	snprintf(options, 7, "%s",
 	    zfs_snapshot_no_setuid ? "nosuid" : "suid");
+
+	/*
+	 * Release z_teardown_lock before potentially blocking operations
+	 * (cv_wait for concurrent mounts, call_usermodehelper for the mount
+	 * helper).  Holding z_teardown_lock(R) across call_usermodehelper
+	 * deadlocks with namespace_sem: the mount helper needs
+	 * namespace_sem(W) via move_mount, while /proc/self/mountinfo
+	 * readers hold namespace_sem(R) and need z_teardown_lock(R) via
+	 * zpl_show_devname.  A concurrent zfs_suspend_fs queuing
+	 * z_teardown_lock(W) blocks new readers, completing the cycle.
+	 * See https://github.com/openzfs/zfs/issues/18409
+	 *
+	 * Releasing the lock allows zfs_suspend_fs to proceed during
+	 * the mount, so dmu_objset_hold in zpl_get_tree can transiently
+	 * fail with ENOENT during the clone swap.  The mount helper
+	 * fails, this function returns EISDIR, and the VFS silently
+	 * falls back to the ctldir stub (empty directory).  The caller
+	 * gets the stub inode instead of the real snapshot root until
+	 * the next access retries the automount.
+	 *
+	 * Safe because everything below operates on local string copies
+	 * (full_name, full_path) or uses its own synchronization
+	 * (zfs_snapshot_lock, se_mtx).  The parent zfsvfs pointer
+	 * remains valid because we hold a path reference to the
+	 * automount trigger dentry.
+	 */
+	zfs_exit(zfsvfs, FTAG);
 
 	/*
 	 * Check if snapshot is already being mounted. If found, wait for


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #18409
Fixes #18073
Upstream PR: https://github.com/openzfs/zfs/pull/18415 (Not yet merged)

`zfsctl_snapshot_mount()` holds `z_teardown_lock(R)` across `call_usermodehelper()`, which needs `namespace_sem(W)` to complete. Reading `/proc/self/mountinfo` holds `namespace_sem(R)` and needs `z_teardown_lock(R)` via `zpl_show_devname`. When `zfs_suspend_fs` (from `zfs recv -F` or `zfs rollback`) queues `z_teardown_lock(W)`, the rrwlock blocks new readers, completing the deadlock cycle.

### Description
<!--- Describe your changes in detail -->
Release `z_teardown_lock(R)` after gathering the dataset name and mount path, before any blocking operation (`cv_wait`, `call_usermodehelper`). The lock is only needed to read `zfsvfs->z_os` and `z_vfs->vfs_mntpoint`, which are copied into local buffers before the release. The parent `zfsvfs` pointer remains valid because the caller holds a path reference to the automount trigger dentry.

Releasing the lock allows zfs_suspend_fs to proceed concurrently with the mount helper, so `dmu_objset_hold` in `zpl_get_tree` transiently fail with `ENOENT` during the clone swap. The mount helper fails, EISDIR is returned, and the VFS falls back to the ctldir stub (empty directory) until the next access retries.

Also fixes a pre-existing leak of the `options` buffer in `zfsctl_snapshot_mount`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Reproduction script from #18409 deadlocks within seconds without the fix. With the fix applied, the same script ran for 12+ hours with no deadlock.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).


Original PR: https://github.com/truenas/zfs/pull/378
