### PR TITLE
NAS-140521 / 26.04 / Use AVL tree lookup in zfsctl_snapdir_vget for mounted snapshots

### DIFF
--- a/module/os/linux/zfs/zfs_ctldir.c
+++ b/module/os/linux/zfs/zfs_ctldir.c
@@ -1408,17 +1408,31 @@ int
 zfsctl_snapdir_vget(struct super_block *sb, uint64_t objsetid, int gen,
     struct inode **ipp)
 {
+	zfsvfs_t *zfsvfs = sb->s_fs_info;
 	int error;
 	struct path path;
 	char *mnt;
 	struct dentry *dentry;
+	zfs_snapentry_t *se;
 
 	mnt = kmem_alloc(MAXPATHLEN, KM_SLEEP);
 
-	error = zfsctl_snapshot_path_objset(sb->s_fs_info, objsetid,
-	    MAXPATHLEN, mnt);
-	if (error)
-		goto out;
+	/*
+	 * Try the in-memory AVL tree first for previously mounted
+	 * snapshots, falling back to the on-disk scan if not found.
+	 */
+	rw_enter(&zfs_snapshot_lock, RW_READER);
+	se = zfsctl_snapshot_find_by_objsetid(zfsvfs->z_os->os_spa, objsetid);
+	rw_exit(&zfs_snapshot_lock);
+	if (se != NULL) {
+		strlcpy(mnt, se->se_path, MAXPATHLEN);
+		zfsctl_snapshot_rele(se);
+	} else {
+		error = zfsctl_snapshot_path_objset(zfsvfs, objsetid,
+		    MAXPATHLEN, mnt);
+		if (error)
+			goto out;
+	}
 
 	/* Trigger automount */
 	error = -kern_path(mnt, LOOKUP_FOLLOW|LOOKUP_DIRECTORY, &path);


### PR DESCRIPTION
zfsctl_snapdir_vget resolves NFS file handles for snapshot directory entries by calling zfsctl_snapshot_path_objset, which iterates all snapshots via dmu_snapshot_list_next to find the matching objsetid. With many snapshots this linear scan is expensive.

For snapshots that have been previously mounted, the path is already cached in the in-memory AVL tree. Check the tree first with zfsctl_snapshot_find_by_objsetid and fall back to the on-disk scan only when the entry is not found.

Reviewed-by: Brian Behlendorf <behlendorf1@llnl.gov>
Reviewed-by: Tony Hutter <hutter2@llnl.gov>

Closes #18429

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
