### PR TITLE
NAS-141170 / 26.0.0-RC.1 / Revert "Add handling for STATX_CHANGE_COOKIE (#343)" (by ixhamza)

### DIFF
--- a/module/os/linux/zfs/zfs_vnops_os.c
+++ b/module/os/linux/zfs/zfs_vnops_os.c
@@ -2614,19 +2614,8 @@ top:
 	if (fuid_dirtied)
 		zfs_fuid_sync(zfsvfs, tx);
 
-	if (mask != 0) {
+	if (mask != 0)
 		zfs_log_setattr(zilog, tx, TX_SETATTR, zp, vap, mask, fuidp);
-		/*
-		 * Ensure that the z_seq is always incremented on setattr
-		 * operation. This is required for change accounting for
-		 * NFS clients.
-		 *
-		 * ATTR_MODE already increments via zfs_acl_chmod_setattr.
-		 * ATTR_SIZE already increments via zfs_freesp.
-		 */
-		if (!(mask & (ATTR_MODE | ATTR_SIZE)))
-			zp->z_seq++;
-	}
 
 	mutex_exit(&zp->z_lock);
 	if (mask & (ATTR_UID|ATTR_GID|ATTR_MODE))

--- a/module/os/linux/zfs/zpl_inode.c
+++ b/module/os/linux/zfs/zpl_inode.c
@@ -506,32 +506,6 @@ zpl_getattr_impl(const struct path *path, struct kstat *stat, u32 request_mask,
 	}
 #endif
 
-#ifdef STATX_CHANGE_COOKIE
-	if (request_mask & STATX_CHANGE_COOKIE) {
-		/*
-		 * knfsd uses the STATX_CHANGE_COOKIE to surface to clients
-		 * change_info4 data, which is used to implement NFS client
-		 * name caching (see RFC 8881 Section 10.8). This number
-		 * should always increase with changes and should not be
-		 * reused. We cannot simply present ctime here because
-		 * ZFS uses a coarse timer to set them, which may cause
-		 * clients to fail to detect changes and invalidate cache.
-		 *
-		 * ZFS always increments znode z_seq number, but this is
-		 * uint_t and so we mask in ctime to upper bits.
-		 *
-		 * STATX_ATTR_CHANGE_MONOTONIC is advertised
-		 * to prevent knfsd from generating the change cookie
-		 * based on ctime. C.f. nfsd4_change_attribute in
-		 * fs/nfsd/nfsfh.c.
-		 */
-		stat->change_cookie =
-		    ((u64)stat->ctime.tv_sec << 32) | zp->z_seq;
-		stat->attributes |= STATX_ATTR_CHANGE_MONOTONIC;
-		stat->result_mask |= STATX_CHANGE_COOKIE;
-	}
-#endif
-
 #ifdef STATX_DIOALIGN
 	if (request_mask & STATX_DIOALIGN) {
 		uint64_t align;


### PR DESCRIPTION
### Motivation and Context
While https://github.com/openzfs/zfs/pull/18573 is under review upstream, revert commit 312bdab0f502.

See https://ixsystems.atlassian.net/browse/NAS-141170 for details.

### Description

### How Has This Been Tested?

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).


Original PR: https://github.com/truenas/zfs/pull/393
