### PR TITLE
NAS-141650 / 26.0.0-RC.1 / Backport several PRs from OpenZFS master (by amotin)

### DIFF
--- a/include/sys/abd.h
+++ b/include/sys/abd.h
@@ -81,8 +81,10 @@ __attribute__((malloc))
 abd_t *abd_alloc(size_t, boolean_t);
 __attribute__((malloc))
 abd_t *abd_alloc_linear(size_t, boolean_t);
+abd_t *abd_alloc_linear_struct(abd_t *, size_t, boolean_t);
 __attribute__((malloc))
 abd_t *abd_alloc_gang(void);
+abd_t *abd_alloc_gang_struct(abd_t *);
 __attribute__((malloc))
 abd_t *abd_alloc_for_io(size_t, boolean_t);
 __attribute__((malloc))
@@ -94,6 +96,7 @@ abd_t *abd_get_offset(abd_t *, size_t);
 abd_t *abd_get_offset_size(abd_t *, size_t, size_t);
 abd_t *abd_get_offset_struct(abd_t *, abd_t *, size_t, size_t);
 abd_t *abd_get_zeros(size_t);
+abd_t *abd_get_zeros_struct(abd_t *, size_t);
 abd_t *abd_get_from_buf(void *, size_t);
 abd_t *abd_get_from_buf_struct(abd_t *, void *, size_t);
 void abd_cache_reap_now(void);

--- a/module/zfs/abd.c
+++ b/module/zfs/abd.c
@@ -212,11 +212,9 @@ abd_alloc(size_t size, boolean_t is_metadata)
  * buffer. Only use this when it would be very annoying to write your ABD
  * consumer with a scattered ABD.
  */
-abd_t *
-abd_alloc_linear(size_t size, boolean_t is_metadata)
+static abd_t *
+abd_alloc_linear_impl(abd_t *abd, size_t size, boolean_t is_metadata)
 {
-	abd_t *abd = abd_alloc_struct(0);
-
 	VERIFY3U(size, <=, SPA_MAXBLOCKSIZE);
 
 	abd->abd_flags |= ABD_FLAG_LINEAR | ABD_FLAG_OWNER;
@@ -234,6 +232,19 @@ abd_alloc_linear(size_t size, boolean_t is_metadata)
 	abd_update_linear_stats(abd, ABDSTAT_INCR);
 
 	return (abd);
+}
+
+abd_t *
+abd_alloc_linear(size_t size, boolean_t is_metadata)
+{
+	return (abd_alloc_linear_impl(abd_alloc_struct(0), size, is_metadata));
+}
+
+abd_t *
+abd_alloc_linear_struct(abd_t *abd, size_t size, boolean_t is_metadata)
+{
+	abd_init_struct(abd);
+	return (abd_alloc_linear_impl(abd, size, is_metadata));
 }
 
 static void
@@ -349,14 +360,26 @@ abd_alloc_sametype(abd_t *sabd, size_t size)
  * to "chain" scatter/gather lists together when constructing aggregated
  * IO's. To free this abd, abd_free() must be called.
  */
-abd_t *
-abd_alloc_gang(void)
+static abd_t *
+abd_alloc_gang_impl(abd_t *abd)
 {
-	abd_t *abd = abd_alloc_struct(0);
 	abd->abd_flags |= ABD_FLAG_GANG | ABD_FLAG_OWNER;
 	list_create(&ABD_GANG(abd).abd_gang_chain,
 	    sizeof (abd_t), offsetof(abd_t, abd_gang_link));
 	return (abd);
+}
+
+abd_t *
+abd_alloc_gang(void)
+{
+	return (abd_alloc_gang_impl(abd_alloc_struct(0)));
+}
+
+abd_t *
+abd_alloc_gang_struct(abd_t *abd)
+{
+	abd_init_struct(abd);
+	return (abd_alloc_gang_impl(abd));
 }
 
 /*
@@ -622,6 +645,14 @@ abd_get_zeros(size_t size)
 	ASSERT3P(abd_zero_scatter, !=, NULL);
 	ASSERT3U(size, <=, SPA_MAXBLOCKSIZE);
 	return (abd_get_offset_size(abd_zero_scatter, 0, size));
+}
+
+abd_t *
+abd_get_zeros_struct(abd_t *abd, size_t size)
+{
+	ASSERT3P(abd_zero_scatter, !=, NULL);
+	ASSERT3U(size, <=, SPA_MAXBLOCKSIZE);
+	return (abd_get_offset_struct(abd, abd_zero_scatter, 0, size));
 }
 
 /*

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -2854,6 +2854,9 @@ metaslab_set_selected_txg(metaslab_t *msp, uint64_t txg)
 {
 	ASSERT(MUTEX_HELD(&msp->ms_lock));
 	metaslab_class_t *mc = msp->ms_group->mg_class;
+	if (msp->ms_selected_txg == txg &&
+	    multilist_link_active(&msp->ms_class_txg_node))
+		return;
 	multilist_sublist_t *mls =
 	    multilist_sublist_lock_obj(&mc->mc_metaslab_txg_list, msp);
 	if (multilist_link_active(&msp->ms_class_txg_node))

--- a/module/zfs/vdev_draid.c
+++ b/module/zfs/vdev_draid.c
@@ -666,7 +666,8 @@ vdev_draid_map_alloc_write(zio_t *zio, uint64_t abd_offset, raidz_row_t *rr)
 		if (rc->rc_size == 0) {
 			/* empty data column (small write), add a skip sector */
 			ASSERT3U(skip_size, ==, parity_size);
-			rc->rc_abd = abd_get_zeros(skip_size);
+			rc->rc_abd = abd_get_zeros_struct(&rc->rc_abdstruct,
+			    skip_size);
 		} else if (rc->rc_size == parity_size) {
 			/* this is a "big column" */
 			rc->rc_abd = abd_get_offset_struct(&rc->rc_abdstruct,
@@ -674,7 +675,7 @@ vdev_draid_map_alloc_write(zio_t *zio, uint64_t abd_offset, raidz_row_t *rr)
 		} else {
 			/* short data column, add a skip sector */
 			ASSERT3U(rc->rc_size + skip_size, ==, parity_size);
-			rc->rc_abd = abd_alloc_gang();
+			rc->rc_abd = abd_alloc_gang_struct(&rc->rc_abdstruct);
 			abd_gang_add(rc->rc_abd, abd_get_offset_size(
 			    zio->io_abd, abd_off, rc->rc_size), B_TRUE);
 			abd_gang_add(rc->rc_abd, abd_get_zeros(skip_size),
@@ -731,7 +732,7 @@ vdev_draid_map_alloc_scrub(zio_t *zio, uint64_t abd_offset, raidz_row_t *rr)
 			/* short data column, add a skip sector */
 			ASSERT3U(rc->rc_size + skip_size, ==, parity_size);
 			ASSERT3U(rr->rr_nempty, !=, 0);
-			rc->rc_abd = abd_alloc_gang();
+			rc->rc_abd = abd_alloc_gang_struct(&rc->rc_abdstruct);
 			abd_gang_add(rc->rc_abd, abd_get_offset_size(
 			    zio->io_abd, abd_off, rc->rc_size), B_TRUE);
 			abd_gang_add(rc->rc_abd, abd_get_offset_size(
@@ -1070,7 +1071,8 @@ vdev_draid_map_alloc_row(zio_t *zio, raidz_row_t **rrp, uint64_t io_offset,
 	/* Allocate buffers for the parity columns */
 	for (uint64_t c = 0; c < rr->rr_firstdatacol; c++) {
 		raidz_col_t *rc = &rr->rr_col[c];
-		rc->rc_abd = abd_alloc_linear(rc->rc_size, B_FALSE);
+		rc->rc_abd = abd_alloc_linear_struct(&rc->rc_abdstruct,
+		    rc->rc_size, B_FALSE);
 	}
 
 	/*

--- a/module/zfs/vdev_raidz.c
+++ b/module/zfs/vdev_raidz.c
@@ -3143,6 +3143,7 @@ vdev_raidz_io_done_verified(zio_t *zio, raidz_row_t *rr)
 	zio_flag_t add_flags = 0;
 
 	ASSERT3U(zio->io_type, ==, ZIO_TYPE_READ);
+	ASSERT0(zio->io_error);
 
 	for (int c = 0; c < rr->rr_cols; c++) {
 		raidz_col_t *rc = &rr->rr_col[c];
@@ -3168,12 +3169,19 @@ vdev_raidz_io_done_verified(zio_t *zio, raidz_row_t *rr)
 	 * reconstruction, confirm that the other parity disks produced
 	 * correct data.
 	 *
-	 * Note that we also regenerate parity when resilvering so we
-	 * can write it out to failed devices later.
+	 * We also regenerate parity to write it back to any failed parity
+	 * columns.  However, if all available parity was consumed by
+	 * reconstruction (parity_verify is false), regenerating parity is
+	 * a mathematical identity -- the result is guaranteed to equal the
+	 * input that was used for reconstruction, whether correct or
+	 * corrupted.  In that case the only reason to regenerate is to
+	 * write back a failed parity column, so skip regeneration when no
+	 * parity column failed or the pool is read-only.
 	 */
 	boolean_t parity_verify = (parity_errors + parity_untried) <
 	    (rr->rr_firstdatacol - data_errors);
-	if (parity_verify || (zio->io_flags & ZIO_FLAG_RESILVER)) {
+	if (parity_verify || (parity_errors > 0 &&
+	    spa_writeable(zio->io_spa))) {
 		int n = raidz_parity_verify(zio, rr);
 		/*
 		 * In, Reed-Solomon encoding, if we have ndata+1 columns and
@@ -3198,7 +3206,7 @@ vdev_raidz_io_done_verified(zio_t *zio, raidz_row_t *rr)
 		unexpected_errors += n;
 	}
 
-	if (zio->io_error == 0 && spa_writeable(zio->io_spa) &&
+	if (spa_writeable(zio->io_spa) &&
 	    (unexpected_errors > 0 || (zio->io_flags & ZIO_FLAG_RESILVER))) {
 		/*
 		 * Use the good data we have in hand to repair damaged children.
@@ -3251,7 +3259,7 @@ vdev_raidz_io_done_verified(zio_t *zio, raidz_row_t *rr)
 	 * necessary, but since expansion is paused during scrub/resilver, at
 	 * most a single row will have a shadow location.
 	 */
-	if (zio->io_error == 0 && spa_writeable(zio->io_spa) &&
+	if (spa_writeable(zio->io_spa) &&
 	    (zio->io_flags & (ZIO_FLAG_RESILVER | ZIO_FLAG_SCRUB))) {
 		for (int c = 0; c < rr->rr_cols; c++) {
 			raidz_col_t *rc = &rr->rr_col[c];

--- a/module/zfs/vdev_raidz.c
+++ b/module/zfs/vdev_raidz.c
@@ -561,12 +561,13 @@ vdev_raidz_map_alloc_write(zio_t *zio, raidz_map_t *rm, uint64_t ashift)
 		 * VDEV queue locks (vq_lock).
 		 */
 		if (c < nwrapped) {
-			rc->rc_abd = abd_alloc_linear(
+			rc->rc_abd = abd_alloc_linear_struct(&rc->rc_abdstruct,
 			    rc->rc_size + (1ULL << ashift), B_FALSE);
 			abd_zero_off(rc->rc_abd, rc->rc_size, 1ULL << ashift);
 			skipped++;
 		} else {
-			rc->rc_abd = abd_alloc_linear(rc->rc_size, B_FALSE);
+			rc->rc_abd = abd_alloc_linear_struct(&rc->rc_abdstruct,
+			    rc->rc_size, B_FALSE);
 		}
 	}
 
@@ -614,9 +615,11 @@ vdev_raidz_map_alloc_read(zio_t *zio, raidz_map_t *rm)
 	ASSERT3U(rm->rm_nrows, ==, 1);
 
 	/* Allocate buffers for the parity columns */
-	for (c = 0; c < rr->rr_firstdatacol; c++)
-		rr->rr_col[c].rc_abd =
-		    abd_alloc_linear(rr->rr_col[c].rc_size, B_FALSE);
+	for (c = 0; c < rr->rr_firstdatacol; c++) {
+		raidz_col_t *rc = &rr->rr_col[c];
+		rc->rc_abd = abd_alloc_linear_struct(&rc->rc_abdstruct,
+		    rc->rc_size, B_FALSE);
+	}
 
 	for (uint64_t off = 0; c < rr->rr_cols; c++) {
 		raidz_col_t *rc = &rr->rr_col[c];
@@ -1061,8 +1064,8 @@ vdev_raidz_map_alloc_expanded(zio_t *zio,
 				continue;
 
 			prc->rc_abd =
-			    abd_alloc_linear(rm->rm_phys_col[i].rc_size,
-			    B_FALSE);
+			    abd_alloc_linear_struct(&prc->rc_abdstruct,
+			    prc->rc_size, B_FALSE);
 		}
 
 		/*
@@ -1090,8 +1093,8 @@ vdev_raidz_map_alloc_expanded(zio_t *zio,
 			for (int c = 0; c < rr->rr_firstdatacol; c++) {
 				raidz_col_t *rc = &rr->rr_col[c];
 				rc->rc_abd =
-				    abd_alloc_linear(rc->rc_size,
-				    B_TRUE);
+				    abd_alloc_linear_struct(&rc->rc_abdstruct,
+				    rc->rc_size, B_TRUE);
 			}
 		}
 	}

--- a/module/zfs/vdev_raidz.c
+++ b/module/zfs/vdev_raidz.c
@@ -409,7 +409,16 @@ static int zfs_scrub_after_expand = 1;
 static void
 vdev_raidz_row_free(raidz_row_t *rr)
 {
-	for (int c = 0; c < rr->rr_cols; c++) {
+	abd_t *dabd = rr->rr_col[rr->rr_firstdatacol].rc_abd;
+	for (int c = 0; c < rr->rr_firstdatacol; c++) {
+		raidz_col_t *rc = &rr->rr_col[c];
+
+		if (rc->rc_size != 0 && rc->rc_abd != dabd)
+			abd_free(rc->rc_abd);
+		if (rc->rc_orig_data != NULL)
+			abd_free(rc->rc_orig_data);
+	}
+	for (int c = rr->rr_firstdatacol; c < rr->rr_cols; c++) {
 		raidz_col_t *rc = &rr->rr_col[c];
 
 		if (rc->rc_size != 0)
@@ -521,6 +530,22 @@ vdev_raidz_map_alloc_write(zio_t *zio, raidz_map_t *rm, uint64_t ashift)
 	 * vdev_raidz_io_start_write().
 	 */
 	int skipped = rr->rr_scols - rr->rr_cols;
+
+	/*
+	 * When there is only a single data column the parity is a copy of
+	 * it, so point all parity columns at the data ABD directly to avoid
+	 * allocating buffers and computing parity.
+	 */
+	if (rr->rr_cols == rr->rr_firstdatacol + 1) {
+		ASSERT0(nwrapped);
+		ASSERT0(rm->rm_nskip);
+		raidz_col_t *dc = &rr->rr_col[rr->rr_firstdatacol];
+		dc->rc_abd = abd_get_offset_struct(&dc->rc_abdstruct,
+		    zio->io_abd, 0, dc->rc_size);
+		for (c = 0; c < rr->rr_firstdatacol; c++)
+			rr->rr_col[c].rc_abd = dc->rc_abd;
+		return;
+	}
 
 	/* Allocate buffers for the parity columns */
 	for (c = 0; c < rr->rr_firstdatacol; c++) {
@@ -1261,6 +1286,13 @@ vdev_raidz_generate_parity_row(raidz_map_t *rm, raidz_row_t *rr)
 		 */
 		return;
 	}
+
+	/*
+	 * Single data column: parity is the data itself.
+	 */
+	if (rr->rr_col[VDEV_RAIDZ_P].rc_abd ==
+	    rr->rr_col[rr->rr_firstdatacol].rc_abd)
+		return;
 
 	/* Generate using the new math implementation */
 	if (vdev_raidz_math_generate(rm, rr) != RAIDZ_ORIGINAL_IMPL)

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -3594,16 +3594,26 @@ zio_ddt_collision(zio_t *zio, ddt_t *ddt, ddt_entry_t *dde)
 		if (dde->dde_io == NULL)
 			continue;
 
+		/*
+		 * Lock dde_io to prevent the lead zio from completing
+		 * and freeing its ABD while we compare against it.
+		 */
+		mutex_enter(&dde->dde_io->dde_io_lock);
 		zio_t *lio = dde->dde_io->dde_lead_zio[p];
-		if (lio == NULL)
+		if (lio == NULL) {
+			mutex_exit(&dde->dde_io->dde_io_lock);
 			continue;
-
-		if (do_raw)
-			return (lio->io_size != zio->io_size ||
-			    abd_cmp(zio->io_abd, lio->io_abd) != 0);
-
-		return (lio->io_orig_size != zio->io_orig_size ||
-		    abd_cmp(zio->io_orig_abd, lio->io_orig_abd) != 0);
+		}
+		boolean_t collision;
+		if (do_raw) {
+			collision = lio->io_size != zio->io_size ||
+			    abd_cmp(zio->io_abd, lio->io_abd) != 0;
+		} else {
+			collision = lio->io_orig_size != zio->io_orig_size ||
+			    abd_cmp(zio->io_orig_abd, lio->io_orig_abd) != 0;
+		}
+		mutex_exit(&dde->dde_io->dde_io_lock);
+		return (collision);
 	}
 
 	for (int p = 0; p < DDT_NPHYS(ddt); p++) {


### PR DESCRIPTION
This includes one bug fix:
 - Fix insufficient locking in dedup verify

, and several performance optimizations:
 - Optimize metaslab_set_selected_txg()
 - RAIDZ: Optimize single data column writes
 - Avoid more abd_t allocations in RAIDZ/dRAID
 - RAIDZ: Fix parity regeneration/check condition

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).


Original PR: https://github.com/truenas/zfs/pull/409
