### PR TITLE
NAS-141403 / 26.0.0-RC.1 / fix key unload failure when unmounting an encryption root (by amotin)

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -7775,6 +7775,8 @@ unshare_unmount_path(int op, char *path, int flags, boolean_t is_manual)
 		}
 		(void) fprintf(stderr, gettext("warning: %s not in"
 		    "/proc/self/mounts\n"), path);
+		/* libzfs-internal flags; umount2(2) rejects them */
+		flags &= ~(MS_CRYPT | MS_OVERLAY);
 		if ((ret = umount2(path, flags)) != 0)
 			(void) fprintf(stderr, gettext("%s: %s\n"), path,
 			    strerror(errno));

--- a/lib/libspl/include/os/freebsd/sys/mount.h
+++ b/lib/libspl/include/os/freebsd/sys/mount.h
@@ -89,17 +89,12 @@
 #endif /* MNT_DETACH */
 
 /*
- * Overlay mount is default in Linux, but for solaris/zfs
- * compatibility, MS_OVERLAY is defined to explicitly have the user
- * provide a flag (-O) to mount over a non empty directory.
+ * MS_OVERLAY (-O: allow mounting over a non-empty directory) and MS_CRYPT
+ * (load/unload encryption keys with the (un)mount) are libzfs-internal flags,
+ * never passed to the kernel.  They use high bits that do_unmount() masks
+ * off before unmount(2); do_mount() builds its iovec from named options.
  */
-#define	MS_OVERLAY	0x00000004
-
-/*
- * MS_CRYPT indicates that encryption keys should be loaded if they are not
- * already available. This is not defined in glibc, but it is never seen by
- * the kernel so it will not cause any problems.
- */
-#define	MS_CRYPT	0x00000008
+#define	MS_OVERLAY	0x20000000
+#define	MS_CRYPT	0x40000000
 
 #endif /* _LIBSPL_SYS_MOUNT_H */

--- a/lib/libspl/include/os/linux/sys/mount.h
+++ b/lib/libspl/include/os/linux/sys/mount.h
@@ -83,17 +83,13 @@
 #endif /* MNT_DETACH */
 
 /*
- * Overlay mount is default in Linux, but for solaris/zfs
- * compatibility, MS_OVERLAY is defined to explicitly have the user
- * provide a flag (-O) to mount over a non empty directory.
+ * MS_OVERLAY (-O: allow mounting over a non-empty directory) and MS_CRYPT
+ * (load/unload encryption keys with the (un)mount) are libzfs-internal flags,
+ * never passed to the kernel.  They use high bits because the old 0x4/0x8
+ * aliased the umount2(2) flags MNT_EXPIRE/UMOUNT_NOFOLLOW; do_unmount() masks
+ * them off before the syscall.
  */
-#define	MS_OVERLAY	0x00000004
-
-/*
- * MS_CRYPT indicates that encryption keys should be loaded if they are not
- * already available. This is not defined in glibc, but it is never seen by
- * the kernel so it will not cause any problems.
- */
-#define	MS_CRYPT	0x00000008
+#define	MS_OVERLAY	0x20000000
+#define	MS_CRYPT	0x40000000
 
 #endif /* _LIBSPL_SYS_MOUNT_H */

--- a/lib/libzfs/libzfs_changelist.c
+++ b/lib/libzfs/libzfs_changelist.c
@@ -88,6 +88,77 @@ struct prop_changelist {
 };
 
 /*
+ * Deferred key unload for "zfs unmount -u". A wrapping key is shared by an
+ * encryption root and the children inheriting it, and unloads only once all
+ * of them are unmounted. The mountpoint-ordered pass 1 can unmount the root
+ * before such a child, so an inline unload would EBUSY; defer it so pass 1
+ * tears down the whole subtree (MS_CRYPT stripped) first, then unload each
+ * encryption root's key here. Returns -1 on failure so the caller re-mounts.
+ */
+static int
+changelist_unload_keys(prop_changelist_t *clp)
+{
+	prop_changenode_t *cn;
+	uu_avl_walk_t *walk;
+	boolean_t encroot;
+	int ret = 0;
+
+	if ((walk = uu_avl_walk_start(clp->cl_tree, UU_WALK_ROBUST)) == NULL)
+		return (-1);
+
+	while ((cn = uu_avl_walk_next(walk)) != NULL && ret == 0) {
+		if (getzoneid() == GLOBAL_ZONEID && cn->cn_zoned)
+			continue;
+		if (ZFS_IS_VOLUME(cn->cn_handle))
+			continue;
+		zfs_refresh_properties(cn->cn_handle);
+		if (zfs_crypto_get_encryption_root(cn->cn_handle, &encroot,
+		    NULL) != 0) {
+			ret = -1;
+		} else if (encroot && zfs_prop_get_int(cn->cn_handle,
+		    ZFS_PROP_KEYSTATUS) == ZFS_KEYSTATUS_AVAILABLE &&
+		    zfs_crypto_unload_key(cn->cn_handle) != 0) {
+			ret = -1;
+		}
+	}
+	uu_avl_walk_end(walk);
+
+	return (ret);
+}
+
+/*
+ * Called when changelist_unload_keys() could not unload a key, typically
+ * because a dataset using it is still in use (e.g. a bind or second mount).
+ * The "zfs unmount -u" cannot complete, so undo it by re-mounting the
+ * datasets we just unmounted, parent-first so a parent is never mounted over
+ * a child. We re-mount each node unconditionally rather than rely on
+ * changelist_postfix(), which only re-mounts a node it finds unmounted: a
+ * bind or second mount can leave a dataset looking mounted while its own
+ * mountpoint is gone, so postfix would skip it. A node whose key was already
+ * unloaded is skipped, since it cannot be mounted without its key.
+ */
+static void
+changelist_remount_subtree(prop_changelist_t *clp)
+{
+	prop_changenode_t *cn;
+	uu_avl_walk_t *walk;
+
+	if ((walk = uu_avl_walk_start(clp->cl_tree,
+	    UU_WALK_REVERSE | UU_WALK_ROBUST)) == NULL)
+		return;
+
+	while ((cn = uu_avl_walk_next(walk)) != NULL) {
+		if (!cn->cn_needpost || !cn->cn_mounted)
+			continue;
+		zfs_refresh_properties(cn->cn_handle);
+		if (zfs_prop_get_int(cn->cn_handle, ZFS_PROP_KEYSTATUS) !=
+		    ZFS_KEYSTATUS_UNAVAILABLE)
+			(void) zfs_mount(cn->cn_handle, NULL, 0);
+	}
+	uu_avl_walk_end(walk);
+}
+
+/*
  * If the property is 'mountpoint', go through and unmount filesystems as
  * necessary.  We don't do the same for 'sharenfs', because we can just re-share
  * with different options without interrupting service. We do handle 'sharesmb'
@@ -140,7 +211,7 @@ changelist_prefix(prop_changelist_t *clp)
 			switch (clp->cl_prop) {
 			case ZFS_PROP_MOUNTPOINT:
 				if (zfs_unmount(cn->cn_handle, NULL,
-				    clp->cl_mflags) != 0) {
+				    clp->cl_mflags & ~MS_CRYPT) != 0) {
 					ret = -1;
 					cn->cn_needpost = B_FALSE;
 				}
@@ -160,6 +231,12 @@ changelist_prefix(prop_changelist_t *clp)
 	if (commit_smb_shares)
 		zfs_commit_shares(smb);
 	uu_avl_walk_end(walk);
+
+	if (ret == 0 && (clp->cl_mflags & MS_CRYPT)) {
+		ret = changelist_unload_keys(clp);
+		if (ret == -1)
+			changelist_remount_subtree(clp);
+	}
 
 	if (ret == -1)
 		(void) changelist_postfix(clp);

--- a/lib/libzfs/os/freebsd/libzfs_zmount.c
+++ b/lib/libzfs/os/freebsd/libzfs_zmount.c
@@ -111,6 +111,13 @@ int
 do_unmount(zfs_handle_t *zhp, const char *mntpt, int flags)
 {
 	(void) zhp;
+
+	/*
+	 * MS_CRYPT and MS_OVERLAY are libzfs-internal flags; keep them out of
+	 * the unmount(2) syscall. MS_FORCE/MS_DETACH are real flags and kept.
+	 */
+	flags &= ~(MS_CRYPT | MS_OVERLAY);
+
 	if (unmount(mntpt, flags) < 0)
 		return (errno);
 	return (0);

--- a/lib/libzfs/os/linux/libzfs_mount_os.c
+++ b/lib/libzfs/os/linux/libzfs_mount_os.c
@@ -386,6 +386,13 @@ do_unmount(zfs_handle_t *zhp, const char *mntpt, int flags)
 {
 	(void) zhp;
 
+	/*
+	 * MS_CRYPT and MS_OVERLAY are libzfs-internal flags; strip them so they
+	 * are never passed to umount2(2), which rejects unknown flag bits with
+	 * EINVAL. MS_FORCE/MS_DETACH are real umount2(2) flags and kept.
+	 */
+	flags &= ~(MS_CRYPT | MS_OVERLAY);
+
 	if (!libzfs_envvar_is_set("ZFS_MOUNT_HELPER")) {
 		int rv = umount2(mntpt, flags);
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_unmount/zfs_unmount_unload_keys.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_unmount/zfs_unmount_unload_keys.ksh
@@ -40,6 +40,8 @@
 # 3. Test that 'zfs unmount -u' unloads keys as it unmounts multiple datasets
 # 4. Test that 'zfs unmount -u' returns an error if the key is still in
 #    use by a clone.
+# 5. Test that 'zfs unmount -u' unloads the key when a key-inheriting child's
+#    mountpoint sorts before its encryption root's.
 #
 
 verify_runnable "both"
@@ -76,5 +78,18 @@ log_must zfs clone $TESTPOOL/$TESTFS2/newroot@1 $TESTPOOL/$TESTFS2/clone
 log_mustnot zfs umount -u $TESTPOOL/$TESTFS2/newroot
 log_must key_available $TESTPOOL/$TESTFS2/newroot
 log_must mounted $TESTPOOL/$TESTFS2/newroot
+
+# The changelist unmounts mountpoints in reverse alphabetical order, so
+# z_root (which sorts after a_child) is unmounted first, before its
+# key-inheriting child. The root comes down while the child still holds the
+# shared key, so the key must unload only after the whole subtree is down.
+log_must eval "echo 'password' | zfs create -o encryption=on -o keyformat=passphrase -o mountpoint=/$TESTPOOL/z_root $TESTPOOL/$TESTFS2/encroot"
+log_must zfs create -o mountpoint=/$TESTPOOL/a_child $TESTPOOL/$TESTFS2/encroot/child
+log_must mounted $TESTPOOL/$TESTFS2/encroot
+log_must mounted $TESTPOOL/$TESTFS2/encroot/child
+log_must zfs umount -u $TESTPOOL/$TESTFS2/encroot
+log_must key_unavailable $TESTPOOL/$TESTFS2/encroot
+log_must unmounted $TESTPOOL/$TESTFS2/encroot
+log_must unmounted $TESTPOOL/$TESTFS2/encroot/child
 
 log_pass "'zfs unmount -u' unloads keys for datasets as they are unmounted"


### PR DESCRIPTION
### Motivation and Context
`zfs unmount -u <encroot>` (unmount a dataset and unload its encryption key) fails with `"Key unload error: '<pool>' is busy"` when a passphrase-encrypted encryption root still has a key-inheriting child mounted. A wrapping key is shared by an encryption root and the children that inherit it, so it can only be unloaded once all of them are unmounted. `changelist_prefix()` unloaded it inline the moment the encryption root was unmounted, but the changelist is ordered by mountpoint rather than by dataset hierarchy, so a key-inheriting child could still be mounted then and the unload failed with `EBUSY`, aborting the operation.

Additionally, the libzfs-internal mount flags `MS_CRYPT` and `MS_OVERLAY` had the values `0x8` and `0x4`, which alias the `umount2(2)` flags `UMOUNT_NOFOLLOW` and `MNT_EXPIRE`. As a result libzfs leaked its own flags into `umount2(2)` and could read a caller's `UMOUNT_NOFOLLOW` as `MS_CRYPT`, unloading the key as an unintended side effect.

### Description
`changelist_prefix()` now strips `MS_CRYPT` in its unmount pass so no key is unloaded inline, tearing the whole subtree down first. Once everything is unmounted it unloads the encryption-root keys in a second pass, stopping at the first failure. If an unload fails because the key is still in use, for example an external bind mount, the subtree is re-mounted parent-first to roll back before the error is returned.

`MS_CRYPT` and `MS_OVERLAY` move off the `0x8`/`0x4` bits to high bits unused by `umount2(2)`, and `do_unmount()` strips them before the unmount syscall (`umount2(2)` on Linux, `unmount(2)` on FreeBSD), as does the `cmd/zfs` unmount-by-path fallback. They never reach `mount(2)`, whose flags come from the parsed mount options rather than these bits, so only the unmount path needs masking. Because `MS_CRYPT` is a compile-time macro in a libspl header, out-of-tree consumers that set it (for example `truenas_pylibzfs`) must be rebuilt against the new value.

### How Has This Been Tested?
A passphrase-encrypted encryption root with a key-inheriting child whose mountpoint sorts before the root's, so the mountpoint-ordered changelist unmounts the root first:
```bash
truncate -s 1G /var/tmp/enc.img
zpool create -o feature@encryption=enabled -O mountpoint=none tank /var/tmp/enc.img
echo password | zfs create -o encryption=on -o keyformat=passphrase \
    -o mountpoint=/mnt/zzz tank/enc
zfs create -o mountpoint=/mnt/aaa tank/enc/child
```
**Before**:

```bash
# zfs unmount -u tank/enc
Key unload error: 'tank/enc' is busy.
# zfs get -Ho value keystatus tank/enc
available
```
**After**:
```bash
# zfs unmount -u tank/enc
# zfs get -Ho value keystatus tank/enc
unavailable
```
### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).


Original PR: https://github.com/truenas/zfs/pull/411
