### PR TITLE
NAS-141854 / 26.0.0-RC.1 / CI: use TrueNAS nightly kernels, publish rolling deb releases (by anodos325)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -94,3 +94,30 @@ Available via `specific_os` or `ZTS_OS_OVERRIDE`:
 - `labels.yml`: maintains PR status labels
 - `zfs-qemu-packages.yml`: manually dispatched, builds release RPMs or
   tests RPM installation from the ZFS yum repo
+
+### TrueNAS fork specifics
+
+The functional matrix is restricted with the `ZTS_OS_OVERRIDE`
+repository variable (currently `["debian13"]`).
+
+Builds and tests run against the TrueNAS production kernel instead of
+the distribution kernel.  The kernel image and development headers are
+consumed from the rolling releases published by
+[truenas/linux](https://github.com/truenas/linux/releases):
+
+| branch                    | train  | kernel release tag |
+|---------------------------|--------|--------------------|
+| `truenas/zfs-2.4-release` | master | `master-nightly`   |
+| `stable/26`               | 26     | `26-nightly`       |
+| any other branch          | master | `master-nightly`   |
+
+- `zfs-qemu.yml` installs the kernel and headers into the Debian VMs
+  and reboots into that kernel before building and testing
+  (`scripts/qemu-tn-kernel.sh`).  PRs follow their base branch; the
+  `kernel_train` dispatch input can force a train (or `none` for the
+  distribution kernel).
+- `ci.yml` builds the native debs in a `debian:trixie` container
+  against the TrueNAS kernel headers and, on every push to
+  `truenas/zfs-2.4-release` or `stable/26`, republishes them as a
+  rolling `<train>-nightly` GitHub release with `SHA256SUMS` and a
+  `manifest.json`, mirroring the truenas/linux kernel releases.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -97,12 +97,19 @@ Available via `specific_os` or `ZTS_OS_OVERRIDE`:
 
 ### TrueNAS fork specifics
 
-The functional matrix is restricted with the `ZTS_OS_OVERRIDE`
-repository variable (currently `["debian13"]`).
+The upstream workflows are kept as close to openzfs/zfs as possible;
+TrueNAS additions live in separate fork-only files.  `zfs-qemu.yml`
+itself is unmodified: its matrix is restricted to `["debian13"]` with
+the `ZTS_OS_OVERRIDE` repository variable and keeps testing the stock
+Debian kernel.
 
-Builds and tests run against the TrueNAS production kernel instead of
-the distribution kernel.  The kernel image and development headers are
-consumed from the rolling releases published by
+`zfs-qemu-tn.yml` (fork-only) runs the same build and test sequence on
+the same Debian 13 image rebooted into the TrueNAS production kernel
+(OS name `debian13-tn`, installed by `scripts/qemu-tn-kernel.sh`).  A
+failure only in zfs-qemu-tn points at the TrueNAS kernel; a failure in
+both workflows points at the ZFS change (or Debian) itself.  The
+kernel image and development headers are consumed from the rolling
+releases published by
 [truenas/linux](https://github.com/truenas/linux/releases):
 
 | branch                    | train  | kernel release tag |
@@ -111,11 +118,8 @@ consumed from the rolling releases published by
 | `stable/26`               | 26     | `26-nightly`       |
 | any other branch          | master | `master-nightly`   |
 
-- `zfs-qemu.yml` installs the kernel and headers into the Debian VMs
-  and reboots into that kernel before building and testing
-  (`scripts/qemu-tn-kernel.sh`).  PRs follow their base branch; the
-  `kernel_train` dispatch input can force a train (or `none` for the
-  distribution kernel).
+- PRs follow their base branch; the `kernel_train` dispatch input of
+  zfs-qemu-tn.yml can force a train.
 - `ci.yml` builds the native debs in a `debian:trixie` container
   against the TrueNAS kernel headers and, on every push to
   `truenas/zfs-2.4-release` or `stable/26`, republishes them as a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,18 +3,76 @@ name: CI
 on: [push]
 
 jobs:
+
   build-native-deb:
+
     runs-on: ubuntu-22.04
+    # The Debian release TrueNAS is based on
     container:
-      image: debian:testing
+      image: debian:trixie
+
+    # Container jobs default run steps to plain sh
+    defaults:
+      run:
+        shell: bash
+
     steps:
+      - name: Map branch to TrueNAS train
+        run: |
+          # All builds run against a rolling TrueNAS production kernel
+          # published by truenas/linux
+          # (https://github.com/truenas/linux/releases).  Branches that
+          # feed a TrueNAS train build against that train's kernel;
+          # everything else defaults to the master train.
+          case "$GITHUB_REF_NAME" in
+            truenas/zfs-2.4-release) train="master" ;;
+            stable/26)               train="26" ;;
+            *)                       train="master" ;;
+          esac
+          echo "TRAIN=$train" >> "$GITHUB_ENV"
+
       - name: Installing Dependencies
         run: |
-          apt update > /dev/null 2>&1
-          apt install -y linux-image-amd64 linux-headers-amd64 debhelper-compat devscripts > /dev/null 2>&1
+          apt-get update > /dev/null 2>&1
+          apt-get install -y ca-certificates curl git jq equivs \
+          debhelper-compat devscripts > /dev/null 2>&1
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      - name: Install TrueNAS kernel headers
+        run: |
+          # Consume the rolling kernel release the same way downstream
+          # consumers are meant to: fetch manifest.json to learn the
+          # current kernel release and file names, then verify the debs
+          # against SHA256SUMS.
+          url="https://github.com/truenas/linux/releases/download/${TRAIN}-nightly"
+          mkdir -p /tmp/tn-kernel
+          cd /tmp/tn-kernel
+          if ! curl --fail -LSs -O "$url/manifest.json" ; then
+            echo "ERROR: no ${TRAIN}-nightly kernel release published at $url yet"
+            exit 1
+          fi
+          curl --fail -LSs -O "$url/SHA256SUMS"
+          release=$(jq -r '.release' manifest.json)
+          echo "TrueNAS $TRAIN kernel: $release"
+          for deb in $(jq -r '.debs[]' manifest.json); do
+            case "$deb" in
+              linux-headers-*)
+                echo "Downloading $deb"
+                curl --fail -LSs -O "$url/$deb"
+                ;;
+            esac
+          done
+          sha256sum -c --ignore-missing SHA256SUMS
+          apt-get install -y ./linux-headers-*.deb
+          # The TrueNAS kernel packages carry version-free names, so
+          # locate the header tree through the build symlink the headers
+          # package ships.
+          ksrc=$(readlink -f "/lib/modules/$release/build")
+          test -f "$ksrc/Module.symvers"
+          echo "KERNEL_RELEASE=$release" >> "$GITHUB_ENV"
+          echo "KSRC=$ksrc" >> "$GITHUB_ENV"
 
       - name: Build deb package
         run: |
@@ -25,16 +83,31 @@ jobs:
           cp -a contrib/debian debian
           sed 's/@CFGOPTS@/--enable-debuginfo/g' debian/rules.in > debian/rules
           chmod +x debian/rules
-          dch -b -M --force-distribution --distribution bullseye-truenas-unstable 'Tagged from zfs CI'
+          # Version the rolling debs above the release build they are
+          # based on so consecutive builds stay upgradeable.
+          dch -b -M \
+            -v "$(dpkg-parsechangelog -S Version)+truenas.$(date -u +%Y%m%d).$GITHUB_RUN_NUMBER" \
+            --force-distribution --distribution "${TRAIN}-nightly" \
+            "Rolling build of $GITHUB_REF_NAME at ${GITHUB_SHA::12}"
           debuild -us -uc -b
-          debian/rules override_dh_binary-modules
+          # Build the kernel modules against the TrueNAS kernel, the
+          # same way scale-build does (KVERS/KSRC/KOBJ).
+          debian/rules override_dh_binary-modules \
+            KVERS="$KERNEL_RELEASE" KSRC="$KSRC" KOBJ="$KSRC"
 
       - name: Create artifacts dir
         run: mkdir artifacts
         if: success()
 
       - name: Move artifacts
-        run: mv ../*.deb artifacts
+        run: |
+          mv ../*.deb artifacts
+          jq -n \
+            --arg train "$TRAIN" \
+            --arg zfs_version "$(dpkg-parsechangelog -S Version)" \
+            --arg kernel_release "$KERNEL_RELEASE" \
+            '{train: $train, zfs_version: $zfs_version, kernel_release: $kernel_release}' \
+            > artifacts/buildinfo.json
         if: success()
 
       - uses: actions/upload-artifact@v4
@@ -42,3 +115,126 @@ jobs:
           name: zfs-native
           path: artifacts
         if: success()
+
+  # On every merge to truenas/zfs-2.4-release or stable/26, republish the
+  # native debs built above (against the TrueNAS production kernel) as
+  # assets of a per-train rolling prerelease (master-nightly and
+  # 26-nightly respectively), mirroring the truenas/linux kernel
+  # releases.  Release assets (unlike Actions artifacts) never expire and
+  # are downloadable anonymously at stable URLs:
+  #   https://github.com/truenas/zfs/releases/download/master-nightly/<file>
+  # Consumers should fetch manifest.json first to learn the current file
+  # names, then verify downloads against SHA256SUMS.
+  publish_latest_debs:
+
+    needs: build-native-deb
+    if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/truenas/zfs-2.4-release' || github.ref == 'refs/heads/stable/26') }}
+
+    runs-on: ubuntu-22.04
+
+    permissions:
+      contents: write
+      actions: read
+
+    concurrency:
+      group: publish-latest-debs-${{ github.ref }}
+      cancel-in-progress: false
+
+    steps:
+
+      - name: Download native debs
+        uses: actions/download-artifact@v4
+        with:
+          name: zfs-native
+          path: zfs-native
+
+      - name: Assemble release assets
+        run: |
+          mkdir release-assets
+          # TrueNAS does not ship the dkms or dracut packages; skip them
+          # to keep the release lean.
+          for deb in zfs-native/*.deb; do
+            case "$(basename "$deb")" in
+              openzfs-zfs-dkms_*|openzfs-zfs-dracut_*)
+                echo "Skipping $(basename "$deb")"
+                ;;
+              *)
+                cp "$deb" release-assets/
+                ;;
+            esac
+          done
+          echo "KERNEL_RELEASE=$(jq -r '.kernel_release' zfs-native/buildinfo.json)" >> "$GITHUB_ENV"
+          echo "ZFS_VERSION=$(jq -r '.zfs_version' zfs-native/buildinfo.json)" >> "$GITHUB_ENV"
+
+      - name: Generate checksums and manifest
+        run: |
+          cd release-assets
+          sha256sum *.deb > SHA256SUMS
+          ls *.deb | jq -R . | jq -s \
+            --arg branch "$GITHUB_REF_NAME" \
+            --arg commit "$GITHUB_SHA" \
+            --arg date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg run_url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            --arg zfs_version "$ZFS_VERSION" \
+            --arg kernel_release "$KERNEL_RELEASE" \
+            '{
+              branch: $branch,
+              commit: $commit,
+              date: $date,
+              run_url: $run_url,
+              zfs_version: $zfs_version,
+              kernel_release: $kernel_release,
+              debs: .
+            }' > manifest.json
+          cat manifest.json
+
+      - name: Publish rolling release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          # If the branch has already moved past this commit, let the run
+          # building the new tip publish instead - the release must never
+          # go back to older debs.
+          tip=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$GITHUB_REF_NAME" --jq .object.sha)
+          if [ "$tip" != "$GITHUB_SHA" ]; then
+            echo "$GITHUB_REF_NAME is now at $tip, not publishing $GITHUB_SHA"
+            exit 0
+          fi
+
+          # Map the branch to its TrueNAS train.  Exact matches only: if a
+          # branch is added to this job's if-gate it must be mapped here
+          # too, otherwise two branches could fight over one release.
+          case "$GITHUB_REF_NAME" in
+            truenas/zfs-2.4-release) train="master" ;;
+            stable/26)               train="26" ;;
+            *)
+              echo "ERROR: no train mapping for branch $GITHUB_REF_NAME"
+              exit 1
+              ;;
+          esac
+          tag="${train}-nightly"
+
+          {
+            echo "Rolling native deb build of \`$GITHUB_REF_NAME\` at $GITHUB_SHA."
+            echo
+            echo "- ZFS version: \`$ZFS_VERSION\`"
+            echo "- Built against kernel: \`$KERNEL_RELEASE\`"
+            echo "  from https://github.com/truenas/linux/releases/tag/$tag"
+            echo "- Build: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            echo
+            echo "The tag and all assets are replaced on every merge to"
+            echo "\`$GITHUB_REF_NAME\`. Fetch \`manifest.json\` to see what is"
+            echo "currently published and verify downloads against \`SHA256SUMS\`."
+          } > release-notes.md
+
+          gh release delete "$tag" --cleanup-tag --yes || true
+          gh api -X DELETE "repos/$GITHUB_REPOSITORY/git/refs/tags/$tag" 2>/dev/null || true
+          gh release create "$tag" \
+            --prerelease \
+            --target "$GITHUB_SHA" \
+            --title "TrueNAS $train OpenZFS debs (nightly)" \
+            --notes-file release-notes.md \
+            release-assets/*.deb \
+            release-assets/SHA256SUMS \
+            release-assets/manifest.json

--- a/.github/workflows/scripts/qemu-1-setup.sh
+++ b/.github/workflows/scripts/qemu-1-setup.sh
@@ -19,13 +19,14 @@ unneeded="microsoft-edge-stable|azure-cli|google-cloud|google-chrome-stable|"\
 "powershell|julia|swift|miniconda|chromium"
 # refresh package index before removing packages
 sudo apt-get -y update
-sudo apt-get -y remove $(dpkg-query -f '${binary:Package}\n' -W | grep -E "'$unneeded'")
+sudo apt-get -y remove $(dpkg-query -f '${binary:Package}\n' -W | grep -E "$unneeded")
 sudo apt-get -y autoremove
 
-# Next, remove unneeded files in /usr.  This frees up an additional 25GB.
+# Next, remove unneeded files in /usr and the preinstalled tool cache.
+# This frees up an additional 35GB.
 sudo rm -fr /usr/local/lib/android /usr/share/dotnet /usr/local/.ghcup \
         /usr/share/swift /usr/local/share/powershell /usr/local/julia* \
-        /usr/share/miniconda /usr/local/share/chromium
+        /usr/share/miniconda /usr/local/share/chromium /opt/hostedtoolcache
 echo "Disk space after:"
 df -h /
 
@@ -130,7 +131,25 @@ if [ -e /dev/disk/cloud/azure_resource-part1 ] ; then
   SWAP=$DISK-part1
 else
   echo "We have a single 150GB block device"
-  sudo fallocate -l 72G /test.ssd2
+
+  # Everything is carved out of the root filesystem here, and the
+  # runner images don't always leave enough free space for the full
+  # 72GiB pool file plus the 16GiB swap file.  Filling / to the last
+  # byte kills the runner (it can no longer write its own logs), so
+  # size the pool file to what is actually available, keeping a
+  # 10GiB reserve for the runner, logs and packages, and fail loudly
+  # when even a minimal pool does not fit.
+  avail=$(df -BG --output=avail / | tail -1 | tr -dc '0-9')
+  ssd2_size=$((avail - 16 - 10))
+  if [ $ssd2_size -gt 72 ]; then
+    ssd2_size=72
+  elif [ $ssd2_size -lt 40 ]; then
+    echo "ERROR: only ${avail}GiB free on /, not enough for a test pool"
+    df -h /
+    exit 1
+  fi
+  echo "Using a ${ssd2_size}GiB pool file (${avail}GiB available)"
+  sudo fallocate -l ${ssd2_size}G /test.ssd2
   SWAP=/swapfile.ssd
   sudo fallocate -l 16G $SWAP
   sudo chmod 600 $SWAP
@@ -143,6 +162,9 @@ sudo swapon $SWAP
 
 echo "Block devices:"
 lsblk
+
+echo "Free space on /:"
+df -h /
 
 # adjust zfs module parameter and create pool
 ARC_MIN=$((1024*1024*256))

--- a/.github/workflows/scripts/qemu-1-setup.sh
+++ b/.github/workflows/scripts/qemu-1-setup.sh
@@ -97,61 +97,95 @@ sudo swapoff -a
 # lrwxrwxrwx 1 root root 11 Jan 29 18:07 azure_root-part14 -> ../../sda14
 # lrwxrwxrwx 1 root root 11 Jan 29 18:07 azure_root-part15 -> ../../sda15
 #
-# If we have the azure_resource-part1 partition, umount it, partition it, and
-# use it as our ZFS disk and swap partition.  If not, just create a file VDEV
-# and swap file and use that instead.
+# If we have an ephemeral resource disk, umount it, partition it, and use it
+# as our ZFS disk and swap partition.  If not, create a file VDEV and swap
+# file on the root filesystem instead.  Newer runner VMs expose the resource
+# disk as NVMe without the azure_resource symlinks, or have none at all.
+echo "Initial block devices:"
+lsblk -o NAME,SIZE,TYPE,MOUNTPOINTS
+
+RESOURCE=""
+if [ -e /dev/disk/cloud/azure_resource ] ; then
+  RESOURCE=$(readlink -f /dev/disk/cloud/azure_resource)
+fi
+
+# ... or the disk backing /mnt, unless something else is mounted from it too
+if [ -z "$RESOURCE" ] ; then
+  MNT_SRC=$(findmnt -n -o SOURCE --mountpoint /mnt || true)
+  case "$MNT_SRC" in
+  /dev/*)
+    PARENT=$(lsblk -n -o PKNAME "$MNT_SRC" | head -n1)
+    RESOURCE="${PARENT:+/dev/$PARENT}"
+    RESOURCE="${RESOURCE:-$MNT_SRC}"
+    if [ -n "$(lsblk -n -o MOUNTPOINTS $RESOURCE | grep -v '^/mnt$' | tr -d '[:space:]')" ] ; then
+      RESOURCE=""
+    fi
+    ;;
+  esac
+fi
+
+# ... or any whole disk of at least 60GiB with nothing mounted from it
+if [ -z "$RESOURCE" ] ; then
+  for dev in $(lsblk -dn -o NAME,TYPE | awk '$2 == "disk" {print "/dev/"$1}'); do
+    test "$(lsblk -dbn -o SIZE $dev)" -ge $((60*1024*1024*1024)) || continue
+    test -z "$(lsblk -n -o MOUNTPOINTS $dev | tr -d '[:space:]')" || continue
+    RESOURCE="$dev"
+    break
+  done
+fi
 
 # remove default swapfile and /mnt
-if [ -e /dev/disk/cloud/azure_resource-part1 ] ; then
-  sudo umount -l /mnt
-  DISK="/dev/disk/cloud/azure_resource-part1"
-  sudo sed -e "s|^$DISK.*||g" -i /etc/fstab
-  sudo wipefs -aq $DISK
+if [ -n "$RESOURCE" ] ; then
+  sudo umount -l /mnt 2>/dev/null || true
+  sudo sed -i '\|^[^#].*[[:space:]]/mnt[[:space:]]|d' /etc/fstab
+  sudo wipefs -aq ${RESOURCE}?* $RESOURCE 2>/dev/null || true
   sudo systemctl daemon-reload
 fi
 
 sudo modprobe loop
 sudo modprobe zfs
 
-if [ -e /dev/disk/cloud/azure_resource-part1 ] ; then
-  echo "We have two 75GB block devices"
+if [ -n "$RESOURCE" ] ; then
+  echo "Using the ephemeral resource disk $RESOURCE"
   # partition the disk as needed
-  DISK="/dev/disk/cloud/azure_resource"
-  sudo sgdisk --zap-all $DISK
+  sudo sgdisk --zap-all $RESOURCE
   sudo sgdisk -p \
    -n 1:0:+16G -c 1:"swap" \
    -n 2:0:0    -c 2:"tests" \
-   $DISK
+   $RESOURCE
+  sudo udevadm settle
   sync
   sleep 1
 
   sudo fallocate -l 12G /test.ssd2
-  DISKS="$DISK-part2 /test.ssd2"
+  # SCSI and NVMe name partitions differently - go by partlabel
+  DISKS="/dev/disk/by-partlabel/tests /test.ssd2"
 
-  SWAP=$DISK-part1
+  SWAP="/dev/disk/by-partlabel/swap"
 else
-  echo "We have a single 150GB block device"
+  echo "No usable resource disk found - using the root filesystem"
 
-  # Everything is carved out of the root filesystem here, and the
-  # runner images don't always leave enough free space for the full
-  # 72GiB pool file plus the 16GiB swap file.  Filling / to the last
-  # byte kills the runner (it can no longer write its own logs), so
-  # size the pool file to what is actually available, keeping a
-  # 10GiB reserve for the runner, logs and packages, and fail loudly
-  # when even a minimal pool does not fit.
+  # Fit pool and swap to the machine - newer VMs have only ~55GiB free.
+  # Keep 8GiB for the runner: filling / to the last byte kills it.
   avail=$(df -BG --output=avail / | tail -1 | tr -dc '0-9')
-  ssd2_size=$((avail - 16 - 10))
+  if [ $avail -ge 88 ]; then
+    swap_size=16
+  else
+    swap_size=8
+  fi
+  ssd2_size=$((avail - swap_size - 8))
   if [ $ssd2_size -gt 72 ]; then
     ssd2_size=72
-  elif [ $ssd2_size -lt 40 ]; then
+  elif [ $ssd2_size -lt 32 ]; then
     echo "ERROR: only ${avail}GiB free on /, not enough for a test pool"
     df -h /
     exit 1
   fi
-  echo "Using a ${ssd2_size}GiB pool file (${avail}GiB available)"
+  echo "Using a ${ssd2_size}GiB pool file and ${swap_size}GiB swap" \
+    "(${avail}GiB available)"
   sudo fallocate -l ${ssd2_size}G /test.ssd2
   SWAP=/swapfile.ssd
-  sudo fallocate -l 16G $SWAP
+  sudo fallocate -l ${swap_size}G $SWAP
   sudo chmod 600 $SWAP
   DISKS="/test.ssd2"
 fi

--- a/.github/workflows/scripts/qemu-2-start.sh
+++ b/.github/workflows/scripts/qemu-2-start.sh
@@ -87,8 +87,10 @@ case "$OS" in
     # TODO: Overwrite OSv to debian13 for virt-install until it's added to osinfo
     OSv="debian12"
     URL="https://cloud.debian.org/images/cloud/trixie/latest/debian-13-generic-amd64.qcow2"
+    # Boot with secure-boot off like the testing VMs in qemu-5-setup.sh,
+    # so locally installed (unsigned) TrueNAS kernels can boot.
     OPTS[0]="--boot"
-    OPTS[1]="uefi=on"
+    OPTS[1]="firmware=efi,firmware.feature0.name=secure-boot,firmware.feature0.enabled=no"
     ;;
   fedora43)
     OSNAME="Fedora 43"

--- a/.github/workflows/scripts/qemu-2-start.sh
+++ b/.github/workflows/scripts/qemu-2-start.sh
@@ -87,8 +87,15 @@ case "$OS" in
     # TODO: Overwrite OSv to debian13 for virt-install until it's added to osinfo
     OSv="debian12"
     URL="https://cloud.debian.org/images/cloud/trixie/latest/debian-13-generic-amd64.qcow2"
+    OPTS[0]="--boot"
+    OPTS[1]="uefi=on"
+    ;;
+  debian13-tn)
+    OSNAME="Debian 13 (TrueNAS kernel)"
+    OSv="debian12"
+    URL="https://cloud.debian.org/images/cloud/trixie/latest/debian-13-generic-amd64.qcow2"
     # Boot with secure-boot off like the testing VMs in qemu-5-setup.sh,
-    # so locally installed (unsigned) TrueNAS kernels can boot.
+    # so the locally installed (unsigned) TrueNAS kernel can boot.
     OPTS[0]="--boot"
     OPTS[1]="firmware=efi,firmware.feature0.name=secure-boot,firmware.feature0.enabled=no"
     ;;

--- a/.github/workflows/scripts/qemu-5-setup.sh
+++ b/.github/workflows/scripts/qemu-5-setup.sh
@@ -26,7 +26,7 @@ case "$OS" in
     # FreeBSD needs only 6GiB
     RAM=6
     ;;
-  debian13)
+  debian13*)
     RAM=8
     # Boot Debian 13 with uefi=on and secureboot=off (ZFS Kernel Module not signed)
     OPTS[0]="--boot"

--- a/.github/workflows/scripts/qemu-tn-kernel-vm.sh
+++ b/.github/workflows/scripts/qemu-tn-kernel-vm.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+######################################################################
+# 3b) install the TrueNAS production kernel.  This is run on the VM.
+#
+# qemu-tn-kernel-vm.sh TRAIN
+#
+# TRAIN: TrueNAS train name ('master' or '26')
+#
+# Downloads the kernel debs published by the truenas/linux CI as the
+# rolling <TRAIN>-nightly GitHub release, verifies them against
+# SHA256SUMS, installs them, and removes the distribution kernels so
+# the next boot can only use the TrueNAS kernel.  Powers the VM off
+# when done.
+######################################################################
+
+set -eu
+
+TRAIN="$1"
+URL="https://github.com/truenas/linux/releases/download/${TRAIN}-nightly"
+
+export DEBIAN_FRONTEND="noninteractive"
+
+echo "##[group]Download TrueNAS $TRAIN kernel"
+mkdir -p /tmp/tn-kernel
+cd /tmp/tn-kernel
+if ! curl --fail -LSs -O "$URL/manifest.json" ; then
+  echo "ERROR: no ${TRAIN}-nightly kernel release published at $URL yet"
+  exit 1
+fi
+curl --fail -LSs -O "$URL/SHA256SUMS"
+RELEASE=$(jq -r '.release' manifest.json)
+echo "Kernel release: $RELEASE" \
+  "($(jq -r '.branch' manifest.json) @ $(jq -r '.commit' manifest.json))"
+
+# Only the image and headers are needed; skip the libc-dev, perf and
+# any debug packages.
+DEBS=""
+for deb in $(jq -r '.debs[]' manifest.json); do
+  case "$deb" in
+    linux-image-*-dbg_*)
+      ;;
+    linux-image-*|linux-headers-*)
+      echo "Downloading $deb"
+      curl --fail -LSs -O "$URL/$deb"
+      DEBS="$DEBS ./$deb"
+      ;;
+  esac
+done
+sha256sum -c --ignore-missing SHA256SUMS
+echo "##[endgroup]"
+
+echo "##[group]Install TrueNAS kernel"
+sudo -E apt-get install -y $DEBS
+echo "##[endgroup]"
+
+echo "##[group]Remove distribution kernels"
+# Let apt remove the running kernel without aborting.
+echo 'linux-base linux-base/removing-running-kernel boolean false' | \
+  sudo debconf-set-selections
+# The TrueNAS kernel packages carry version-free names
+# (linux-{image,headers}-truenas-production-amd64), so tell them apart
+# from the distribution kernels by name.
+STOCK=$(dpkg-query -W -f '${Package}\n' 'linux-image-*' 'linux-headers-*' | \
+  grep -v -- truenas || true)
+if [ -n "$STOCK" ]; then
+  sudo -E apt-get purge -y $STOCK
+fi
+sudo update-grub
+echo "##[endgroup]"
+
+# The TrueNAS kernel must now be the one and only installed kernel,
+# and the module build must resolve to its development headers.
+test -e "/boot/vmlinuz-$RELEASE"
+test "$(ls /boot/vmlinuz-* | wc -l)" -eq 1
+test -f "$(readlink -f "/lib/modules/$RELEASE/build")/Module.symvers"
+rm -rf /tmp/tn-kernel
+
+# reset cloud-init configuration and poweroff
+sudo cloud-init clean --logs
+sleep 2 && sudo poweroff &
+exit 0

--- a/.github/workflows/scripts/qemu-tn-kernel.sh
+++ b/.github/workflows/scripts/qemu-tn-kernel.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+######################################################################
+# 3b) boot the build VM into the TrueNAS production kernel
+#
+# qemu-tn-kernel.sh TRAIN
+#
+# TRAIN: TrueNAS train name ('master' or '26') whose rolling kernel
+#        release (<TRAIN>-nightly) published by truenas/linux should
+#        be installed.
+#
+# The dependency step powered the VM off.  Bring it back up, replace
+# the distribution kernel with the TrueNAS production kernel and power
+# it off again, so the build and test steps that follow run under the
+# TrueNAS kernel.
+######################################################################
+
+set -eu
+
+TRAIN="$1"
+
+sudo virsh start openzfs
+.github/workflows/scripts/qemu-wait-for-vm.sh vm0
+
+scp .github/workflows/scripts/qemu-tn-kernel-vm.sh zfs@vm0:qemu-tn-kernel-vm.sh
+PID=$(pidof /usr/bin/qemu-system-x86_64)
+ssh zfs@vm0 "./qemu-tn-kernel-vm.sh $TRAIN"
+
+# wait for poweroff to succeed
+tail --pid=$PID -f /dev/null
+sleep 5 # avoid this: "error: Domain is already active"
+rm -f $HOME/.ssh/known_hosts

--- a/.github/workflows/zfs-qemu-tn.yml
+++ b/.github/workflows/zfs-qemu-tn.yml
@@ -1,0 +1,135 @@
+# TrueNAS-only workflow, not present upstream.  Runs the zfs-qemu test
+# sequence on the Debian 13 image rebooted into the TrueNAS production
+# kernel (debian13-tn), alongside the unmodified upstream zfs-qemu
+# workflow which keeps testing the stock Debian kernel.  Comparing the
+# two attributes a failure to the TrueNAS kernel (fails only here) or
+# to the ZFS change itself (fails in both).
+name: zfs-qemu-tn
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      kernel_train:
+        type: string
+        required: false
+        default: ""
+        description: "(optional) TrueNAS kernel train to test ('master' or '26'; default: mapped from the branch)"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  test-config:
+    name: Setup
+    if: github.event_name == 'pull_request' || github.repository != 'openzfs/zfs'
+    runs-on: ubuntu-24.04
+    outputs:
+      ci_type: ${{ steps.os.outputs.ci_type }}
+      kernel_train: ${{ steps.kernel.outputs.kernel_train }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Generate CI type
+        id: os
+        run: |
+          ci_type="default"
+
+          # determine CI type when running on PR
+          if ${{ github.event_name == 'pull_request' }}; then
+            head=${{ github.event.pull_request.head.sha }}
+            base=${{ github.event.pull_request.base.sha }}
+            read ci_type ci_source <<< "$(python3 .github/workflows/scripts/generate-ci-type.py $head $base)"
+          fi
+
+          echo "ci_type=$ci_type" | tee -a $GITHUB_OUTPUT
+      - name: Determine TrueNAS kernel train
+        id: kernel
+        run: |
+          # The VM boots the TrueNAS production kernel published by the
+          # truenas/linux rolling releases (<train>-nightly).  Branches
+          # that feed a TrueNAS train use that train's kernel (PRs
+          # follow their base branch); everything else defaults to the
+          # master train.
+          if ${{ github.event_name == 'pull_request' }}; then
+            ref="${{ github.base_ref }}"
+          else
+            ref="${{ github.ref_name }}"
+          fi
+
+          case "$ref" in
+            truenas/zfs-2.4-release) train="master" ;;
+            stable/26)               train="26" ;;
+            *)                       train="master" ;;
+          esac
+
+          # Manual override from workflow_dispatch
+          if [ -n "${{ github.event.inputs.kernel_train }}" ]; then
+            train="${{ github.event.inputs.kernel_train }}"
+          fi
+
+          echo "kernel_train=$train" | tee -a $GITHUB_OUTPUT
+
+  qemu-vm-tn:
+    name: qemu-x86 (debian13-tn)
+    needs: [ test-config ]
+    if: >-
+      (github.event_name == 'pull_request' ||
+      github.repository != 'openzfs/zfs') &&
+      needs.test-config.outputs.ci_type != 'docs'
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Setup QEMU
+      timeout-minutes: 60
+      run: .github/workflows/scripts/qemu-1-setup.sh
+
+    - name: Start build machine
+      timeout-minutes: 10
+      run: .github/workflows/scripts/qemu-2-start.sh debian13-tn
+
+    - name: Install dependencies
+      timeout-minutes: 60
+      run: .github/workflows/scripts/qemu-3-deps.sh --poweroff debian13-tn
+
+    - name: Install TrueNAS kernel
+      timeout-minutes: 20
+      run: .github/workflows/scripts/qemu-tn-kernel.sh ${{ needs.test-config.outputs.kernel_train }}
+
+    - name: Build modules
+      timeout-minutes: 30
+      run: .github/workflows/scripts/qemu-4-build.sh --poweroff --enable-debug debian13-tn
+
+    - name: Setup testing machines
+      timeout-minutes: 5
+      run: .github/workflows/scripts/qemu-5-setup.sh
+
+    - name: Run tests
+      timeout-minutes: 270
+      run: .github/workflows/scripts/qemu-6-tests.sh
+      env:
+        CI_TYPE: ${{ needs.test-config.outputs.ci_type }}
+
+    - name: Prepare artifacts
+      if: always()
+      timeout-minutes: 10
+      run: .github/workflows/scripts/qemu-7-prepare.sh
+
+    - uses: actions/upload-artifact@v7
+      id: artifact-upload
+      if: always()
+      with:
+        name: Logs-functional-debian13-tn
+        path: /tmp/qemu-debian13-tn.tar.bz2
+        archive: false
+        if-no-files-found: ignore
+
+    - name: Test Summary
+      if: always()
+      run: .github/workflows/scripts/qemu-8-summary.sh '${{ steps.artifact-upload.outputs.artifact-url }}'

--- a/.github/workflows/zfs-qemu.yml
+++ b/.github/workflows/zfs-qemu.yml
@@ -15,6 +15,11 @@ on:
         required: false
         default: ""
         description: "(optional) Only run on this specific OS (like 'fedora44' or 'alpine3-23')"
+      kernel_train:
+        type: string
+        required: false
+        default: ""
+        description: "(optional) TrueNAS kernel train to install on Debian VMs ('master', '26', or 'none' for the distribution kernel)"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
@@ -28,6 +33,7 @@ jobs:
     outputs:
       test_os: ${{ steps.os.outputs.os }}
       ci_type: ${{ steps.os.outputs.ci_type }}
+      kernel_train: ${{ steps.kernel.outputs.kernel_train }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -88,6 +94,35 @@ jobs:
 
           echo "os=$os_json" | tee -a $GITHUB_OUTPUT
           echo "ci_type=$ci_type" | tee -a $GITHUB_OUTPUT
+      - name: Determine TrueNAS kernel train
+        id: kernel
+        run: |
+          # Debian VMs boot the TrueNAS production kernel published by the
+          # truenas/linux rolling releases (<train>-nightly).  Branches
+          # that feed a TrueNAS train use that train's kernel (PRs follow
+          # their base branch); everything else defaults to the master
+          # train.
+          if ${{ github.event_name == 'pull_request' }}; then
+            ref="${{ github.base_ref }}"
+          else
+            ref="${{ github.ref_name }}"
+          fi
+
+          case "$ref" in
+            truenas/zfs-2.4-release) train="master" ;;
+            stable/26)               train="26" ;;
+            *)                       train="master" ;;
+          esac
+
+          # Manual override from workflow_dispatch
+          if [ -n "${{ github.event.inputs.kernel_train }}" ]; then
+            train="${{ github.event.inputs.kernel_train }}"
+            if [ "$train" == "none" ]; then
+              train=""
+            fi
+          fi
+
+          echo "kernel_train=$train" | tee -a $GITHUB_OUTPUT
 
   qemu-vm:
     name: qemu-x86
@@ -124,6 +159,11 @@ jobs:
     - name: Install dependencies
       timeout-minutes: 60
       run: .github/workflows/scripts/qemu-3-deps.sh --poweroff ${{ matrix.os }} ${{ github.event.inputs.fedora_kernel_ver }}
+
+    - name: Install TrueNAS kernel
+      if: needs.test-config.outputs.kernel_train != '' && startsWith(matrix.os, 'debian')
+      timeout-minutes: 20
+      run: .github/workflows/scripts/qemu-tn-kernel.sh ${{ needs.test-config.outputs.kernel_train }}
 
     - name: Build modules
       timeout-minutes: 30

--- a/.github/workflows/zfs-qemu.yml
+++ b/.github/workflows/zfs-qemu.yml
@@ -15,11 +15,6 @@ on:
         required: false
         default: ""
         description: "(optional) Only run on this specific OS (like 'fedora44' or 'alpine3-23')"
-      kernel_train:
-        type: string
-        required: false
-        default: ""
-        description: "(optional) TrueNAS kernel train to install on Debian VMs ('master', '26', or 'none' for the distribution kernel)"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
@@ -33,7 +28,6 @@ jobs:
     outputs:
       test_os: ${{ steps.os.outputs.os }}
       ci_type: ${{ steps.os.outputs.ci_type }}
-      kernel_train: ${{ steps.kernel.outputs.kernel_train }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -94,35 +88,6 @@ jobs:
 
           echo "os=$os_json" | tee -a $GITHUB_OUTPUT
           echo "ci_type=$ci_type" | tee -a $GITHUB_OUTPUT
-      - name: Determine TrueNAS kernel train
-        id: kernel
-        run: |
-          # Debian VMs boot the TrueNAS production kernel published by the
-          # truenas/linux rolling releases (<train>-nightly).  Branches
-          # that feed a TrueNAS train use that train's kernel (PRs follow
-          # their base branch); everything else defaults to the master
-          # train.
-          if ${{ github.event_name == 'pull_request' }}; then
-            ref="${{ github.base_ref }}"
-          else
-            ref="${{ github.ref_name }}"
-          fi
-
-          case "$ref" in
-            truenas/zfs-2.4-release) train="master" ;;
-            stable/26)               train="26" ;;
-            *)                       train="master" ;;
-          esac
-
-          # Manual override from workflow_dispatch
-          if [ -n "${{ github.event.inputs.kernel_train }}" ]; then
-            train="${{ github.event.inputs.kernel_train }}"
-            if [ "$train" == "none" ]; then
-              train=""
-            fi
-          fi
-
-          echo "kernel_train=$train" | tee -a $GITHUB_OUTPUT
 
   qemu-vm:
     name: qemu-x86
@@ -159,11 +124,6 @@ jobs:
     - name: Install dependencies
       timeout-minutes: 60
       run: .github/workflows/scripts/qemu-3-deps.sh --poweroff ${{ matrix.os }} ${{ github.event.inputs.fedora_kernel_ver }}
-
-    - name: Install TrueNAS kernel
-      if: needs.test-config.outputs.kernel_train != '' && startsWith(matrix.os, 'debian')
-      timeout-minutes: 20
-      run: .github/workflows/scripts/qemu-tn-kernel.sh ${{ needs.test-config.outputs.kernel_train }}
 
     - name: Build modules
       timeout-minutes: 30

--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -135,6 +135,11 @@ cfr_reason = 'Kernel copy_file_range support required'
 #
 statx_reason = 'Needed statx(2) field not supported on this kernel'
 
+#
+# LUKS requires the device-mapper crypt target in the kernel.
+#
+dm_crypt_reason = 'Kernel dm-crypt (CONFIG_DM_CRYPT) support required'
+
 if sys.platform.startswith('freebsd'):
     cfr_cross_reason = 'copy_file_range(2) cross-filesystem needs FreeBSD 14+'
 else:
@@ -371,6 +376,7 @@ elif sys.platform.startswith('linux'):
         'io/io_uring': ['SKIP', 'io_uring support required'],
         'limits/filesystem_limit': ['SKIP', known_reason],
         'limits/snapshot_limit': ['SKIP', known_reason],
+        'luks/luks_sanity': ['SKIP', dm_crypt_reason],
         'stat/statx_dioalign': ['SKIP', 'statx_reason'],
     })
 

--- a/tests/zfs-tests/tests/functional/luks/luks_sanity.ksh
+++ b/tests/zfs-tests/tests/functional/luks/luks_sanity.ksh
@@ -39,6 +39,13 @@
 
 verify_runnable "both"
 
+# LUKS is layered on the kernel's device-mapper crypt target, which
+# not every kernel provides (CONFIG_DM_CRYPT).  dm_crypt may be built
+# in or a loadable module; modprobe succeeds for both.
+if ! modprobe dm_crypt 2>/dev/null; then
+	log_unsupported "Kernel does not provide the dm-crypt device-mapper target"
+fi
+
 VDEV=$(mktemp --suffix=luks_sanity)
 TESTPOOL=testpool
 


### PR DESCRIPTION
Consume the production kernel from the rolling <train>-nightly releases published by truenas/linux instead of the stock Debian kernel: truenas/zfs-2.4-release -> master, stable/26 -> 26, all other branches (and PRs, via their base branch) -> master.

zfs-qemu.yml installs the kernel and headers into the Debian VM (verified against SHA256SUMS) and purges the distribution kernels, so modules build against and ZTS runs under the TrueNAS kernel.  A kernel_train dispatch input can force a train or 'none'.  debian13 now boots with secure-boot off since the kernel is unsigned.

ci.yml builds the native debs in debian:trixie against the same headers (KVERS/KSRC/KOBJ, like scale-build) and, on pushes to the two mapped branches, republishes them as a rolling <train>-nightly prerelease with SHA256SUMS and manifest.json, mirroring the truenas/linux kernel release workflow. 

These native debs will be consumed in various repos such as truenas/samba and truenas/truenas_pylibzfs that build against our ZFS.


Original PR: https://github.com/truenas/zfs/pull/413
