### PR TITLE
NAS-143895 / 27.0.0-BETA.1 / zgenhostid: seed the generated hostid from the system CSPRNG

### DIFF
--- a/cmd/zgenhostid.c
+++ b/cmd/zgenhostid.c
@@ -34,8 +34,38 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
-#include <time.h>
 #include <unistd.h>
+
+/*
+ * Fill buf with len bytes from the system CSPRNG.  Returns 0 on success
+ * and -1 on failure, with errno set.
+ */
+static int
+get_random_bytes(void *buf, size_t len)
+{
+	int fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
+	if (fd < 0)
+		return (-1);
+
+	size_t got = 0;
+	while (got < len) {
+		ssize_t n = read(fd, (char *)buf + got, len - got);
+		if (n <= 0) {
+			if (n < 0 && errno == EINTR)
+				continue;
+			if (n == 0)
+				errno = EIO;
+			int saved = errno;
+			(void) close(fd);
+			errno = saved;
+			return (-1);
+		}
+		got += (size_t)n;
+	}
+
+	(void) close(fd);
+	return (0);
+}
 
 static __attribute__((noreturn)) void
 usage(void)
@@ -59,7 +89,7 @@ main(int argc, char **argv)
 {
 	/* default file path, can be optionally set by user */
 	const char *path = "/etc/hostid";
-	/* holds converted user input or lrand48() generated value */
+	/* holds converted user input or generated value */
 	unsigned long input_i = 0;
 
 	int opt;
@@ -112,12 +142,24 @@ main(int argc, char **argv)
 	}
 
 	/*
-	 * generate if not provided by user
-	 * also handle unlikely zero return from lrand48()
+	 * Generate if not provided by user. The hostid identifies
+	 * this machine to ZFS multihost protection, so it must be
+	 * unique. Obtain a value from the system CSPRNG to ensure
+	 * that even on systems that share a common image and boot
+	 * deterministically different hostids will be generated.
+	 * The loop handles the unlikely zero return case.
 	 */
 	while (input_i == 0) {
-		srand48(getpid() ^ time(NULL));
-		input_i = lrand48();
+		uint32_t rnd;
+
+		if (get_random_bytes(&rnd, sizeof (rnd)) != 0) {
+			(void) fprintf(stderr,
+			    "zgenhostid: failed to read /dev/urandom: %s\n",
+			    strerror(errno));
+			exit(EXIT_FAILURE);
+		}
+
+		input_i = rnd;
 	}
 
 	FILE *fp = fopen(path, "wb");


### PR DESCRIPTION
Backport of openzfs/zfs#18934 (`7e1cb1374`), cherry-picked with `-x`. Applies cleanly to `truenas/zfs-2.4-release` with no conflicts.

### Why this one matters for TrueNAS specifically

`truenas-installer` calls `zgenhostid` as its first install step whenever `/etc/hostid` is absent, so this code path runs on essentially every fresh install. The old seed was `srand48(getpid() ^ time(NULL))`, and neither input is unpredictable at that moment:

* On a machine with no usable RTC the clock has not yet been set from the network, and systemd has already advanced it to the epoch compiled into the image — the same constant for every machine booting that ISO.
* The PID reached at that point of the install is a function of the boot sequence, so it repeats across installs of the same image.

Two installs can therefore write byte-identical hostids. We hit this in the field: two unrelated machines installed from the same image ended up sharing a hostid.

Reproduced on Proxmox with the RTC forced to a past date (`--startdate 2018-01-01T00:00:00`): two VMs with identical virtual hardware, installed unattended from the same ISO, produced the same `/etc/hostid`. In the live installer both showed `RTC time: 2018-01-01` against a system clock advanced to the image's fixed epoch, with `System clock synchronized: no`.

### Testing

* `scripts/cstyle.pl cmd/zgenhostid.c` clean.
* Builds clean under `-Wall -Wextra`.
* Repeated runs produce unrelated values; an explicit argument still round-trips exactly (`0x5eb04b77` → `77 4b b0 5e`, native byte order preserved); overwrite protection without `-f` unchanged.
* Generated values now cover the full 32-bit range — `lrand48()` returned 31 bits, so previously no generated hostid ever had the high bit set.

### Request

It would be great to be able to backport this in to `release/25.10.x`. As far as I can tell those branches don't descend from `truenas/zfs-2.4-release`, and `cmd/zgenhostid.c` is currently byte-identical across `truenas/zfs-2.4-release`, `release/25.10.3` and `release/25.10.7` — so this PR on its own won't reach the 25.10 train, which is where the affected machines are.
